### PR TITLE
Use svh instead of vh when supported by browser

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -41,6 +41,7 @@ export default function App({
           'flex h-screen flex-col bg-background text-text',
           sourceSansPro.className
         )}
+        style={{ height: '100svh' }}
       >
         <Navbar />
         <Component {...props} />


### PR DESCRIPTION
svh is small viewport height, so this fixes the problem where in mobile, usually there will be a toolbar in top. That makes in chat page, user needs to scroll to bottom to see the input.

with this, the browser won't be scrollable (outside of the chat list) and the input will be visible at start in bottom