### PR TITLE
Remove space id from send message param

### DIFF
--- a/src/components/chats/ChatRoom/ChatForm.tsx
+++ b/src/components/chats/ChatRoom/ChatForm.tsx
@@ -24,7 +24,6 @@ import { HiOutlineExclamationTriangle } from 'react-icons/hi2'
 
 export type ChatFormProps = Omit<ComponentProps<'form'>, 'onSubmit'> & {
   postId: string
-  spaceId: string
   onSubmit?: () => void
 }
 
@@ -35,7 +34,6 @@ function processMessage(message: string) {
 export default function ChatForm({
   className,
   postId,
-  spaceId,
   onSubmit,
   ...props
 }: ChatFormProps) {
@@ -106,7 +104,7 @@ export default function ChatForm({
 
     if (shouldSendMessage) {
       setMessage('')
-      sendMessage({ message: processedMessage, rootPostId: postId, spaceId })
+      sendMessage({ message: processedMessage, rootPostId: postId })
       onSubmit?.()
     } else {
       if (isLoggedIn) {
@@ -120,7 +118,6 @@ export default function ChatForm({
         captchaToken,
         message: processMessage(message),
         rootPostId: postId,
-        spaceId,
       })
       setIsRequestingEnergy(true)
       sendEvent('request energy and send message')

--- a/src/components/chats/ChatRoom/ChatRoom.tsx
+++ b/src/components/chats/ChatRoom/ChatRoom.tsx
@@ -8,7 +8,6 @@ export type ChatRoomProps = ComponentProps<'div'> & {
   asContainer?: boolean
   scrollableContainerClassName?: string
   postId: string
-  spaceId: string
 }
 
 export default function ChatRoom({
@@ -16,7 +15,6 @@ export default function ChatRoom({
   asContainer,
   scrollableContainerClassName,
   postId,
-  spaceId,
   ...props
 }: ChatRoomProps) {
   const Component = asContainer ? Container<'div'> : 'div'
@@ -41,7 +39,7 @@ export default function ChatRoom({
         scrollContainerRef={scrollContainerRef}
       />
       <Component className='mt-auto flex py-3'>
-        <ChatForm onSubmit={scrollToBottom} postId={postId} spaceId={spaceId} />
+        <ChatForm onSubmit={scrollToBottom} postId={postId} />
       </Component>
     </div>
   )

--- a/src/modules/_c/ChatPage/ChatPage.tsx
+++ b/src/modules/_c/ChatPage/ChatPage.tsx
@@ -4,7 +4,6 @@ import DefaultLayout from '@/components/layouts/DefaultLayout'
 import useLastReadMessageId from '@/hooks/useLastReadMessageId'
 import { getPostQuery } from '@/services/api/query'
 import { useCommentIdsByPostId } from '@/services/subsocial/commentIds'
-import { getSpaceId } from '@/utils/env/client'
 import { getIpfsContentUrl } from '@/utils/ipfs'
 import Image, { ImageProps } from 'next/image'
 import { useEffect } from 'react'
@@ -42,7 +41,6 @@ export default function ChatPage({ postId }: { postId: string }) {
     >
       <ChatPageNavbarExtension />
       <ChatRoom
-        spaceId={getSpaceId()}
         postId={postId}
         asContainer
         className='flex-1 overflow-hidden'

--- a/src/services/subsocial/commentIds/mutation.ts
+++ b/src/services/subsocial/commentIds/mutation.ts
@@ -31,7 +31,7 @@ export function useSendMessage(config?: MutationConfig<SendMessageParams>) {
 
       return {
         tx: substrateApi.tx.posts.createPost(
-          params.spaceId,
+          null,
           { Comment: { parentId: null, rootPostId: params.rootPostId } },
           IpfsContent(cid)
         ),

--- a/src/services/subsocial/commentIds/types.ts
+++ b/src/services/subsocial/commentIds/types.ts
@@ -1,7 +1,6 @@
 export type SendMessageParams = {
   message: string
   rootPostId: string
-  spaceId: string
 }
 export type OptimisticMessageIdData = {
   address: string


### PR DESCRIPTION
Send message is using a comment, so there is no need for sending space id because it won't be used anyway.

It will just seem weird if you are accessing a chat outside of the provided list in homepage.
It will make you seem like sending message to a space id that from the env.

For example, you are accessing /c/500 in which the space id is 100
where the env space id is 5

then in the chain, you will send message to space id 5, not 100.