### PR TITLE
Fix login issue

### DIFF
--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -1,4 +1,6 @@
 import useLoginAndRequestToken from '@/hooks/useLoginAndRequestToken'
+import useToastError from '@/hooks/useToastError'
+import { ApiRequestTokenResponse } from '@/pages/api/request-token'
 import { useMyAccount } from '@/stores/my-account'
 import { isTouchDevice } from '@/utils/device'
 import { SyntheticEvent, useRef, useState } from 'react'
@@ -24,8 +26,17 @@ export default function LoginModal({
   const [privateKey, setPrivateKey] = useState('')
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const [hasStartCaptcha, setHasStartCaptcha] = useState(false)
-  const { mutateAsync: loginAndRequestToken, isLoading: loadingRequestToken } =
-    useLoginAndRequestToken()
+  const {
+    mutateAsync: loginAndRequestToken,
+    isLoading: loadingRequestToken,
+    error,
+  } = useLoginAndRequestToken()
+  useToastError<ApiRequestTokenResponse>(
+    error,
+    'Create account failed',
+    (e) => e.message
+  )
+
   const isLoading = loadingRequestToken || hasStartCaptcha
 
   const onSubmit = async (e: SyntheticEvent) => {

--- a/src/components/chats/ChatRoom/ChatForm.tsx
+++ b/src/components/chats/ChatRoom/ChatForm.tsx
@@ -2,7 +2,6 @@ import Send from '@/assets/icons/send.svg'
 import { buttonStyles } from '@/components/Button'
 import CaptchaInvisible from '@/components/captcha/CaptchaInvisible'
 import TextArea from '@/components/inputs/TextArea'
-import Toast from '@/components/Toast'
 import { ESTIMATED_ENERGY_FOR_ONE_TX } from '@/constants/chat'
 import useRequestTokenAndSendMessage from '@/hooks/useRequestTokenAndSendMessage'
 import useToastError from '@/hooks/useToastError'
@@ -19,8 +18,6 @@ import {
   useRef,
   useState,
 } from 'react'
-import { toast } from 'react-hot-toast'
-import { HiOutlineExclamationTriangle } from 'react-icons/hi2'
 
 export type ChatFormProps = Omit<ComponentProps<'form'>, 'onSubmit'> & {
   postId: string
@@ -55,11 +52,13 @@ export default function ChatForm({
   } = useRequestTokenAndSendMessage()
   useToastError<ApiRequestTokenResponse>(
     errorRequestTokenAndSendMessage,
+    'Create account failed',
     (e) => e.message
   )
 
   const [message, setMessage] = useState('')
   const { mutate: sendMessage, error } = useSendMessage()
+  useToastError(error, 'Message failed to send, please try again')
 
   useEffect(() => {
     textAreaRef.current?.focus()
@@ -68,22 +67,6 @@ export default function ChatForm({
   useEffect(() => {
     setIsRequestingEnergy(false)
   }, [hasEnoughEnergy])
-
-  useEffect(() => {
-    if (error) {
-      toast.custom((t) => (
-        <Toast
-          t={t}
-          icon={(classNames) => (
-            <HiOutlineExclamationTriangle className={classNames} />
-          )}
-          title='Message failed to send, please try again'
-          description={error?.message}
-        />
-      ))
-      setIsRequestingEnergy(false)
-    }
-  }, [error])
 
   const shouldSendMessage =
     isRequestingEnergy || (isLoggedIn && hasEnoughEnergy)

--- a/src/hooks/useToastError.tsx
+++ b/src/hooks/useToastError.tsx
@@ -5,7 +5,8 @@ import { HiOutlineExclamationTriangle } from 'react-icons/hi2'
 
 export default function useToastError<ErrorType>(
   error: unknown,
-  getMessage: (error: ErrorType) => string
+  errorTitle: string,
+  getMessage?: (error: ErrorType) => string
 ) {
   const getMessageRef = useRef(getMessage)
   useEffect(() => {
@@ -13,7 +14,7 @@ export default function useToastError<ErrorType>(
       let message: string | undefined = (error as any)?.message
 
       const response = (error as any)?.response?.data
-      if (response) {
+      if (response && getMessageRef.current) {
         const responseMessage = getMessageRef.current(response)
         if (responseMessage) message = responseMessage
       }
@@ -24,10 +25,10 @@ export default function useToastError<ErrorType>(
           icon={(classNames) => (
             <HiOutlineExclamationTriangle className={classNames} />
           )}
-          title='Sign up failed, please try again'
+          title={errorTitle}
           description={message}
         />
       ))
     }
-  }, [error])
+  }, [error, errorTitle])
 }

--- a/src/stores/my-account.ts
+++ b/src/stores/my-account.ts
@@ -160,10 +160,16 @@ export const useMyAccount = create<State & Actions>()((set, get) => ({
     set({ isInitialized: false })
 
     const encodedSecretKey = localStorage.getItem(ACCOUNT_STORAGE_KEY)
+    let successLogin = false
     if (encodedSecretKey) {
       const secretKey = decodeSecretKey(encodedSecretKey)
-      await login(secretKey, true)
-    } else {
+      const address = await login(secretKey, true)
+
+      if (address) successLogin = true
+      else localStorage.removeItem(ACCOUNT_STORAGE_KEY)
+    }
+
+    if (!successLogin) {
       await _syncSessionWithLocalStorage()
     }
     set({ isInitialized: true })

--- a/src/stores/my-account.ts
+++ b/src/stores/my-account.ts
@@ -108,7 +108,9 @@ export const useMyAccount = create<State & Actions>()((set, get) => ({
   },
   _getSecretKeyForLogin: async () => {
     const { _isNewSessionKey, _currentSessionSecretKey } = get()
-    if (_isNewSessionKey) return _currentSessionSecretKey
+    if (_isNewSessionKey && _currentSessionSecretKey)
+      return _currentSessionSecretKey
+
     const { secretKey } = await generateAccount()
     return secretKey
   },


### PR DESCRIPTION
# Problem
If the user have logged in before the change of the secretKey encrypting algorithm (change to sr25519), the localStorage will still have `account` with `secretKey with ed25519`

This will make when init my account store, it will fail login, but the session key is not initialized, where the user will create an account (call `login` function) with empty string as the secret key (the return value of `_getSecretKeyForLogin`)

# Solution
- Check is login in init success? 
  if yes, then don't need to init session, because it will use the session from login.
  if no, then delete the local storage value, and init session
- `_getSecretKeyForLogin` check if the `_currentSessionSecretKey` has value, only if it is, and `_isNewSessionKey` is true, then it will be used. 
  Other than that, just generate new secret key (previously, only check `_isNewSessionKey` is true, so there are case where return value of `_getSecretKeyForLogin` is empty string)

# Other Change
- Remove static error title in `useToastError`, change to additional param instead
- Refactor code to use `useToastError`
- Handle error when `create an account` (`loginAndRequestToken`)