### PR TITLE
Add styles to fix blur in safari

### DIFF
--- a/src/modules/IntegrateChatPage.tsx
+++ b/src/modules/IntegrateChatPage.tsx
@@ -8,6 +8,7 @@ import ClickableImage from '@/components/ClickableImage'
 import Container from '@/components/Container'
 import FixedBottomActionLayout from '@/components/layouts/FixedBottomActionLayout'
 import { useSendEvent } from '@/stores/analytics'
+import { getBlurFallbackStyles } from '@/utils/class-names'
 import Image from 'next/image'
 import { useInView } from 'react-intersection-observer'
 
@@ -56,7 +57,10 @@ export default function IntegrateChatPage() {
             native social integrations
           </p>
           <div className='relative !z-0 flex flex-col items-center gap-4'>
-            <div className='visible absolute top-1/2 !z-0 w-full -translate-y-1/2 rounded-full bg-background-accent pt-[100%] blur-[225px]' />
+            <div
+              className='visible absolute top-1/2 !z-0 w-full -translate-y-1/2 rounded-full bg-background-accent pt-[100%] blur-[225px]'
+              style={getBlurFallbackStyles()}
+            />
             <ClickableImage
               src={EmbedImage}
               alt=''

--- a/src/modules/LaunchCommunityPage.tsx
+++ b/src/modules/LaunchCommunityPage.tsx
@@ -9,6 +9,7 @@ import FixedBottomActionLayout from '@/components/layouts/FixedBottomActionLayou
 import LinkText from '@/components/LinkText'
 import { SUGGEST_FEATURE_LINK } from '@/constants/links'
 import { useSendEvent } from '@/stores/analytics'
+import { getBlurFallbackStyles } from '@/utils/class-names'
 import Image from 'next/image'
 import { useInView } from 'react-intersection-observer'
 
@@ -76,14 +77,7 @@ export default function LaunchCommunityPage() {
           <div className='relative !z-0'>
             <div
               className='visible absolute top-0 !z-0 h-full w-full rounded-full bg-background-accent blur-[225px]'
-              style={{
-                backfaceVisibility: 'hidden',
-                MozBackfaceVisibility: 'hidden',
-                WebkitBackfaceVisibility: 'hidden',
-                transform: 'translate3d(0, 0, 0)',
-                msTransform: 'translate3d(0, 0, 0)',
-                WebkitTransform: 'translate3d(0, 0, 0)',
-              }}
+              style={getBlurFallbackStyles()}
             />
             <ClickableImage
               src={CustomizeImage}
@@ -123,14 +117,7 @@ export default function LaunchCommunityPage() {
           <div className='relative !z-0'>
             <div
               className='visible absolute top-0 !z-0 h-full w-full rounded-full bg-background-accent blur-[225px]'
-              style={{
-                backfaceVisibility: 'hidden',
-                MozBackfaceVisibility: 'hidden',
-                WebkitBackfaceVisibility: 'hidden',
-                transform: 'translate3d(0, 0, 0)',
-                msTransform: 'translate3d(0, 0, 0)',
-                WebkitTransform: 'translate3d(0, 0, 0)',
-              }}
+              style={getBlurFallbackStyles()}
             />
             <Image
               src={FeaturesImage}

--- a/src/modules/LaunchCommunityPage.tsx
+++ b/src/modules/LaunchCommunityPage.tsx
@@ -74,7 +74,17 @@ export default function LaunchCommunityPage() {
             bubbles, logos, and more!
           </p>
           <div className='relative !z-0'>
-            <div className='visible absolute top-0 !z-0 h-full w-full rounded-full bg-background-accent blur-[225px]' />
+            <div
+              className='visible absolute top-0 !z-0 h-full w-full rounded-full bg-background-accent blur-[225px]'
+              style={{
+                backfaceVisibility: 'hidden',
+                MozBackfaceVisibility: 'hidden',
+                WebkitBackfaceVisibility: 'hidden',
+                transform: 'translate3d(0, 0, 0)',
+                msTransform: 'translate3d(0, 0, 0)',
+                WebkitTransform: 'translate3d(0, 0, 0)',
+              }}
+            />
             <ClickableImage
               src={CustomizeImage}
               alt=''
@@ -111,7 +121,17 @@ export default function LaunchCommunityPage() {
             Discuss NFTs and other web3 assets.
           </p>
           <div className='relative !z-0'>
-            <div className='visible absolute top-0 !z-0 h-full w-full rounded-full bg-background-accent blur-[225px]' />
+            <div
+              className='visible absolute top-0 !z-0 h-full w-full rounded-full bg-background-accent blur-[225px]'
+              style={{
+                backfaceVisibility: 'hidden',
+                MozBackfaceVisibility: 'hidden',
+                WebkitBackfaceVisibility: 'hidden',
+                transform: 'translate3d(0, 0, 0)',
+                msTransform: 'translate3d(0, 0, 0)',
+                WebkitTransform: 'translate3d(0, 0, 0)',
+              }}
+            />
             <Image
               src={FeaturesImage}
               alt=''

--- a/src/utils/class-names.ts
+++ b/src/utils/class-names.ts
@@ -1,6 +1,18 @@
 import { cva } from 'class-variance-authority'
 import clsx from 'clsx'
+import { CSSProperties } from 'react'
 import { twMerge } from 'tailwind-merge'
+
+export function getBlurFallbackStyles(): CSSProperties {
+  return {
+    backfaceVisibility: 'hidden',
+    MozBackfaceVisibility: 'hidden',
+    WebkitBackfaceVisibility: 'hidden',
+    transform: 'translate3d(0, 0, 0)',
+    msTransform: 'translate3d(0, 0, 0)',
+    WebkitTransform: 'translate3d(0, 0, 0)',
+  }
+}
 
 export function cx(...params: Parameters<typeof clsx>) {
   return twMerge(clsx(params))


### PR DESCRIPTION
`filter: blur(...px)` won't work in safari (at least some versions) if the blur amount is more than `100px`

to fix this, I need to add some styles which won't affect the UI but will make the blur works