### PR TITLE
Improvement random name

### DIFF
--- a/src/utils/random-name.ts
+++ b/src/utils/random-name.ts
@@ -8,7 +8,7 @@ import {
 export function generateRandomName(seed: string | undefined | null) {
   let hashedSeed = seed
   if (seed) {
-    const hashObj = crypto.createHash('sha256')
+    const hashObj = crypto.createHash('sha512')
     hashedSeed = hashObj.update(seed).digest().toString('hex')
   }
   return uniqueNamesGenerator({

--- a/src/utils/random-name.ts
+++ b/src/utils/random-name.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import {
   adjectives,
   animals,
@@ -5,11 +6,15 @@ import {
 } from 'unique-names-generator'
 
 export function generateRandomName(seed: string | undefined | null) {
-  const base64Seed = seed ? Buffer.from(seed).toString('base64') : undefined
+  let hashedSeed = seed
+  if (seed) {
+    const hashObj = crypto.createHash('sha256')
+    hashedSeed = hashObj.update(seed).digest().toString('hex')
+  }
   return uniqueNamesGenerator({
     dictionaries: [adjectives, animals],
     separator: ' ',
-    seed: base64Seed,
+    seed: hashedSeed ?? undefined,
     style: 'capital',
   })
 }

--- a/src/utils/random-name.ts
+++ b/src/utils/random-name.ts
@@ -4,11 +4,12 @@ import {
   uniqueNamesGenerator,
 } from 'unique-names-generator'
 
-export function generateRandomName(seed: string) {
+export function generateRandomName(seed: string | undefined | null) {
+  const base64Seed = seed ? Buffer.from(seed).toString('base64') : undefined
   return uniqueNamesGenerator({
     dictionaries: [adjectives, animals],
     separator: ' ',
-    seed,
+    seed: base64Seed,
     style: 'capital',
   })
 }


### PR DESCRIPTION
# Problem
In current implementation, using seed (which is substrate address) directly as seed can result in same name.
In the current instance of problem, which can be seen in image below,
![image](https://user-images.githubusercontent.com/53143942/232085688-2da0e7ee-0e5e-4b24-ae3b-513b2603144c.png)

The problem is, the lib used is using sum of ASCII number for all the characters, and in this case, those 2 addresses results in same number.
I assume this may often happen because we use same substrate address format, which has similar first parts.

# Solution
Hash it before using it as seed (using SHA512 so the hash will be longer and the chance those will have same sum will be smaller)
![image](https://user-images.githubusercontent.com/53143942/232086367-a0d0606d-50ba-42b2-a7c3-52ebcd05c475.png)
