### PR TITLE
Disable default context menu

### DIFF
--- a/src/components/chats/ChatItem/ChatItem.tsx
+++ b/src/components/chats/ChatItem/ChatItem.tsx
@@ -125,7 +125,10 @@ export default function ChatItem({
         {(_, onContextMenu, referenceProps) => {
           return (
             <div
-              className={cx('flex flex-col overflow-hidden', props.className)}
+              className={cx(
+                'flex select-none flex-col overflow-hidden',
+                props.className
+              )}
               onContextMenu={onContextMenu}
               onDoubleClick={() => setChatAsReply(commentId)}
               {...referenceProps}

--- a/src/components/chats/ChatItem/ChatItem.tsx
+++ b/src/components/chats/ChatItem/ChatItem.tsx
@@ -125,10 +125,7 @@ export default function ChatItem({
         {(_, onContextMenu, referenceProps) => {
           return (
             <div
-              className={cx(
-                'flex select-none flex-col overflow-hidden',
-                props.className
-              )}
+              className={cx('flex flex-col overflow-hidden', props.className)}
               onContextMenu={onContextMenu}
               onDoubleClick={() => setChatAsReply(commentId)}
               {...referenceProps}

--- a/src/components/floating/CommonCustomContextMenu.tsx
+++ b/src/components/floating/CommonCustomContextMenu.tsx
@@ -19,7 +19,7 @@ export default function CommonCustomContextMenu({
   return (
     <CustomContextMenu
       menuPanel={(closeMenu) => (
-        <DefaultContextMenu closeMenu={closeMenu} {...props} />
+        <CommonContextMenu closeMenu={closeMenu} {...props} />
       )}
       allowedPlacements={allowedPlacements}
     >
@@ -28,7 +28,7 @@ export default function CommonCustomContextMenu({
   )
 }
 
-function DefaultContextMenu({ menus, closeMenu }: DefaultContextMenuProps) {
+function CommonContextMenu({ menus, closeMenu }: DefaultContextMenuProps) {
   return (
     <ul className='flex w-32 flex-col overflow-hidden rounded-lg bg-background-light py-1 shadow-[0_5px_50px_-12px_rgb(0,0,0)]'>
       {menus.map(({ onClick, text, icon }) => (

--- a/src/components/floating/CustomContextMenu.tsx
+++ b/src/components/floating/CustomContextMenu.tsx
@@ -61,10 +61,8 @@ export default function CustomContextMenu({
   }
 
   const onContextMenu: MouseEventHandler<Element> = (e) => {
-    if (window.getSelection()?.type !== 'Range') {
-      e.preventDefault()
-      toggleMenu(e)
-    }
+    e.preventDefault()
+    toggleMenu(e)
   }
 
   const closeMenu = () => setOpenMenu(false)


### PR DESCRIPTION
Currently, our custom context menu (right click menus) are displayed only if the user is not selecting any text.

Now, even if user is selecting text, the menu will be displayed everytime they right click on it