### PR TITLE
Increase minimum character before truncation

### DIFF
--- a/src/components/chats/ChatItem/RepliedMessagePreview.tsx
+++ b/src/components/chats/ChatItem/RepliedMessagePreview.tsx
@@ -13,7 +13,7 @@ export type RepliedMessagePreviewProps = ComponentProps<'div'> & {
   getRepliedElement?: (commentId: string) => Promise<HTMLElement | null>
 }
 
-const MINIMUM_REPLY_CHAR = 20
+const MINIMUM_REPLY_CHAR = 35
 export default function RepliedMessagePreview({
   repliedMessageId,
   originalMessage,


### PR DESCRIPTION
# Problem
The character is truncating too soon
It seems the problem is because before, I made it using the truncateAddress when showing the message, now that we changed to animal names, which are longer, making the chat bubble bigger even if you only had 1 character of text.
![image](https://user-images.githubusercontent.com/53143942/232863372-e0f1d3b4-5a6e-4358-8559-90df9f54fbfd.png)

# Solution
Increase the minimum text
