### PR TITLE
Improvement UI for light theme

### DIFF
--- a/src/@types/theme.d.ts
+++ b/src/@types/theme.d.ts
@@ -1,0 +1,1 @@
+export type Theme = 'light' | 'dark'

--- a/src/components/AddressAvatar.tsx
+++ b/src/components/AddressAvatar.tsx
@@ -11,7 +11,7 @@ export type AddressAvatarProps = ComponentProps<'div'> & {
 
 const AddressAvatar = forwardRef<HTMLDivElement, AddressAvatarProps>(
   function AddressAvatar({ address, ...props }: AddressAvatarProps, ref) {
-    const backgroundColor = useRandomColor(address)
+    const backgroundColor = useRandomColor(address, 'dark')
     const avatar = useMemo(() => {
       return createAvatar(bottts, {
         size: 128,

--- a/src/components/ColorModeToggler.tsx
+++ b/src/components/ColorModeToggler.tsx
@@ -28,7 +28,7 @@ export default function ColorModeToggler({ ...props }: ColorModeTogglerProps) {
       {...props}
       onClick={handleClick}
     >
-      {theme === 'dark' ? <HiSun /> : <HiMoon />}
+      {theme === 'dark' ? <HiSun /> : <HiMoon className='text-text-muted' />}
     </Button>
   )
 }

--- a/src/components/navbar/Navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar/Navbar.tsx
@@ -2,7 +2,7 @@ import Button from '@/components/Button'
 import ColorModeToggler from '@/components/ColorModeToggler'
 import Container from '@/components/Container'
 import Logo from '@/components/Logo'
-import useIsInFrame from '@/hooks/useIsInFrame'
+import useIsInIframe from '@/hooks/useIsInFrame'
 import usePrevious from '@/hooks/usePrevious'
 import { useMyAccount } from '@/stores/my-account'
 import { cx } from '@/utils/class-names'
@@ -29,7 +29,7 @@ export default function Navbar({ customContent, ...props }: NavbarProps) {
   const isInitializedAddress = useMyAccount(
     (state) => state.isInitializedAddress
   )
-  const isInFrame = useIsInFrame()
+  const isInFrame = useIsInIframe()
   const address = useMyAccount((state) => state.address)
   const prevAddress = usePrevious(address)
   const isLoggedIn = !!address

--- a/src/hooks/useGetTheme.ts
+++ b/src/hooks/useGetTheme.ts
@@ -1,6 +1,7 @@
+import { Theme } from '@/@types/theme'
 import { useTheme } from 'next-themes'
 
-export default function useGetTheme() {
+export default function useGetTheme(): Theme | undefined {
   const { theme, systemTheme } = useTheme()
   if (theme === undefined) return undefined
   const isDark =

--- a/src/hooks/useIsInFrame.ts
+++ b/src/hooks/useIsInFrame.ts
@@ -1,12 +1,12 @@
 import { getIsInIframe } from '@/utils/window'
 import { useEffect, useState } from 'react'
 
-export default function useIsInFrame() {
-  const [isInFrame, setIsInFrame] = useState(false)
+export default function useIsInIframe() {
+  const [isInIframe, setIsInIframe] = useState(false)
 
   useEffect(() => {
-    setIsInFrame(getIsInIframe())
+    setIsInIframe(getIsInIframe())
   }, [])
 
-  return isInFrame
+  return isInIframe
 }

--- a/src/hooks/useRandomColor.ts
+++ b/src/hooks/useRandomColor.ts
@@ -1,7 +1,11 @@
+import { Theme } from '@/@types/theme'
 import { generateRandomColor } from '@/utils/random-colors'
 import useGetTheme from './useGetTheme'
 
-export default function useRandomColor(seed: string | null | undefined) {
-  const theme = useGetTheme()
-  return generateRandomColor(seed, theme)
+export default function useRandomColor(
+  seed: string | null | undefined,
+  theme?: Theme
+) {
+  const currentTheme = useGetTheme()
+  return generateRandomColor(seed, theme ?? currentTheme)
 }

--- a/src/modules/_c/ChatPage/ChatPage.tsx
+++ b/src/modules/_c/ChatPage/ChatPage.tsx
@@ -1,6 +1,7 @@
 import Button from '@/components/Button'
 import ChatRoom from '@/components/chats/ChatRoom'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
+import useIsInIframe from '@/hooks/useIsInFrame'
 import useLastReadMessageId from '@/hooks/useLastReadMessageId'
 import { getPostQuery } from '@/services/api/query'
 import { useCommentIdsByPostId } from '@/services/subsocial/commentIds'
@@ -63,10 +64,16 @@ function NavbarChatInfo({
   topic: string
 }) {
   const router = useRouter()
+  const isInIframe = useIsInIframe()
   return (
     <div className='flex items-center'>
       <div className='mr-2 flex w-9 items-center justify-center'>
-        <Button size='circle' onClick={router.back} variant='transparent'>
+        <Button
+          size='circle'
+          href={isInIframe ? undefined : '/'}
+          onClick={isInIframe ? router.back : undefined}
+          variant='transparent'
+        >
           <HiOutlineChevronLeft />
         </Button>
       </div>


### PR DESCRIPTION
# Changes
- Make back button in chat page redirect to `/` instead of `router.back` if not in iframe
because if using router back, when the user access chat page directly, it will redirect you back to your browser's home page
- Change color of color toggler to dark mode to be lighter
- Change address avatar to use colors in dark theme
After:
![image](https://user-images.githubusercontent.com/53143942/232873274-b2a1489b-212b-4450-a9bb-5ba971f1cb77.png)
Before:
![image](https://user-images.githubusercontent.com/53143942/232873295-464dc69b-6373-4155-abd8-7a292cc214ea.png)
