### PR TITLE
Update scrollbar styles everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "prettier-plugin-organize-imports": "^3.2.2",
     "prettier-plugin-tailwindcss": "^0.2.3",
     "pretty-quick": "^3.1.3",
-    "tailwind-scrollbar": "^2.1.0",
+    "tailwind-scrollbar": "^3.0.0",
     "tailwindcss": "^3.2.7"
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -43,6 +43,10 @@
   display: none;
 }
 
+* {
+  @apply scrollbar-thin scrollbar-track-background-lightest scrollbar-thumb-background-light scrollbar-track-rounded-full scrollbar-thumb-rounded-full dark:scrollbar-track-background-light dark:scrollbar-thumb-background-lighter;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -44,7 +44,7 @@
 }
 
 * {
-  @apply scrollbar-thin scrollbar-track-background-lightest scrollbar-thumb-background-light scrollbar-track-rounded-full scrollbar-thumb-rounded-full dark:scrollbar-track-background-light dark:scrollbar-thumb-background-lighter;
+  @apply scrollbar-thin scrollbar-track-background scrollbar-thumb-background-lightest scrollbar-track-rounded-full scrollbar-thumb-rounded-full dark:scrollbar-thumb-background-lighter;
 }
 
 @tailwind base;

--- a/src/utils/class-names.ts
+++ b/src/utils/class-names.ts
@@ -42,12 +42,7 @@ export const scrollBarStyles = cva('', {
   variants: {
     none: {
       true: cx('scrollbar-none'),
-      false: cx(
-        'flex-1 overflow-auto pr-2',
-        'scrollbar-thin',
-        'scrollbar-thumb-background-light scrollbar-track-background-light/50',
-        'scrollbar-track-rounded-full scrollbar-thumb-rounded-full'
-      ),
+      false: cx('flex-1 overflow-auto'),
     },
   },
   defaultVariants: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5952,10 +5952,10 @@ tailwind-merge@^1.10.0:
   resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-1.10.0.tgz#535541c7373d8a31afa81a4267e2ab9b4afa9429"
   integrity sha512-WFnDXSS4kFTZwjKg5/oZSGzBRU/l+qcbv5NVTzLUQvJ9yovDAP05h0F2+ZFW0Lw9EcgRoc2AfURUdZvnEFrXKg==
 
-tailwind-scrollbar@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tailwind-scrollbar/-/tailwind-scrollbar-2.1.0.tgz#46e0b8788cef75387f9d163a5ec82b8cacd66c44"
-  integrity sha512-zpvY5mDs0130YzYjZKBiDaw32rygxk5RyJ4KmeHjGnwkvbjm/PszON1m4Bbt2DkMRIXlXsfNevykAESgURN4KA==
+tailwind-scrollbar@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tailwind-scrollbar/-/tailwind-scrollbar-3.0.0.tgz#efc233195afc69bcae4cff393600d31fabe7860c"
+  integrity sha512-OkVRX9Q1T769vk979UZ519jhj/j/zNBHql7zPLI+tlhX+ahksYO4ZryWD29lOETDx9Wj1sw+K1OeW7W3+ECQOA==
 
 tailwindcss@^3.2.7:
   version "3.2.7"


### PR DESCRIPTION
Implement same scrollbar styles throughout the app.
Need to update the tailwind-scrollbar because in previous version, if implemented like this, all element will got scrollbars


dark theme:
![image](https://user-images.githubusercontent.com/53143942/234038806-90cafca1-baf3-49c3-9237-cf783065469a.png)
light theme:
![image](https://user-images.githubusercontent.com/53143942/234038882-e52b7f3e-ed2d-4fa6-b286-3a5c0b419cd8.png)
