### PR TITLE
Enable back to previous url

### DIFF
--- a/src/components/navbar/Navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar/Navbar.tsx
@@ -4,6 +4,7 @@ import Container from '@/components/Container'
 import Logo from '@/components/Logo'
 import useIsInIframe from '@/hooks/useIsInIframe'
 import usePrevious from '@/hooks/usePrevious'
+import { useLocation } from '@/stores/location'
 import { useMyAccount } from '@/stores/my-account'
 import { cx } from '@/utils/class-names'
 import dynamic from 'next/dynamic'
@@ -29,6 +30,8 @@ export default function Navbar({ customContent, ...props }: NavbarProps) {
   const isInitializedAddress = useMyAccount(
     (state) => state.isInitializedAddress
   )
+  const prevUrl = useLocation((state) => state.prevUrl)
+
   const isInIframe = useIsInIframe()
   const address = useMyAccount((state) => state.address)
   const prevAddress = usePrevious(address)
@@ -91,15 +94,12 @@ export default function Navbar({ customContent, ...props }: NavbarProps) {
             customContent(authComponent, colorModeToggler)
           ) : (
             <div className='flex items-center justify-between'>
-              {isInIframe ? (
-                <span>
-                  <Logo className='text-2xl' />
-                </span>
-              ) : (
-                <Link href='/' aria-label='Back to home'>
-                  <Logo className='text-2xl' />
-                </Link>
-              )}
+              <Link
+                href={(isInIframe && prevUrl) || '/'}
+                aria-label='Back to home'
+              >
+                <Logo className='text-2xl' />
+              </Link>
               <div className='flex items-center gap-4'>
                 {colorModeToggler}
                 {authComponent}

--- a/src/modules/_c/ChatPage/ChatPage.tsx
+++ b/src/modules/_c/ChatPage/ChatPage.tsx
@@ -5,6 +5,7 @@ import useIsInIframe from '@/hooks/useIsInIframe'
 import useLastReadMessageId from '@/hooks/useLastReadMessageId'
 import { getPostQuery } from '@/services/api/query'
 import { useCommentIdsByPostId } from '@/services/subsocial/commentIds'
+import { useLocation } from '@/stores/location'
 import { getIpfsContentUrl } from '@/utils/ipfs'
 import { PostData } from '@subsocial/api/types'
 import Image, { ImageProps } from 'next/image'
@@ -63,20 +64,17 @@ function NavbarChatInfo({
   messageCount: number
   post?: PostData | null
 }) {
+  const prevUrl = useLocation((state) => state.prevUrl)
   const isInIframe = useIsInIframe()
 
-  if (!post) return null
-
-  const { content, struct } = post
-  const topic = content?.title
-  const { spaceId } = struct
+  const topic = post?.content?.title
 
   return (
     <div className='flex items-center'>
       <div className='mr-2 flex w-9 items-center justify-center'>
         <Button
           size='circle'
-          href={isInIframe ? `/${spaceId ?? ''}` : '/'}
+          href={(isInIframe && prevUrl) || '/'}
           nextLinkProps={{ replace: isInIframe }}
           variant='transparent'
         >

--- a/src/modules/_c/ChatPage/ChatPage.tsx
+++ b/src/modules/_c/ChatPage/ChatPage.tsx
@@ -68,13 +68,14 @@ function NavbarChatInfo({
   const isInIframe = useIsInIframe()
 
   const topic = post?.content?.title
+  const spaceId = post?.struct?.spaceId
 
   return (
     <div className='flex items-center'>
       <div className='mr-2 flex w-9 items-center justify-center'>
         <Button
           size='circle'
-          href={(isInIframe && prevUrl) || '/'}
+          href={prevUrl || `/${spaceId ?? ''}`}
           nextLinkProps={{ replace: isInIframe }}
           variant='transparent'
         >

--- a/src/stores/location.ts
+++ b/src/stores/location.ts
@@ -1,0 +1,23 @@
+import { Router } from 'next/router'
+import { create } from './utils'
+
+type State = {
+  currentUrl: string
+  prevUrl: string
+}
+
+const initialState: State = {
+  currentUrl: '',
+  prevUrl: '',
+}
+
+export const useLocation = create<State>()((set, get) => ({
+  ...initialState,
+  init: () => {
+    set({ currentUrl: window.location.href })
+    Router.events.on('routeChangeComplete', () => {
+      const prevUrl = get().currentUrl
+      set({ currentUrl: window.location.href, prevUrl })
+    })
+  },
+}))


### PR DESCRIPTION
# Problem
Before, its using static /[spaceId] to back to home in iframe. This is a problem because the actual url you need to go back to have the queries for sorting and theme, which is not in the static /[spaceId].

Also, when not in iframe, when you go back, it will back to `/`, but it should be back to the `/spaceId`, but if you access it from e.g. polka.grill.chat, you want it to back to that, not polka.grill.chat/1005.

# Solution
Create a zustand store that saves current and prev url, and use it in the href

For problem 2, solution is to use prevUrl if exist, if not just use the /spaceId