### PR TITLE
Change chat preview bg to white in dark mode

### DIFF
--- a/src/components/chats/ChatPreview/ChatPreview.tsx
+++ b/src/components/chats/ChatPreview/ChatPreview.tsx
@@ -61,12 +61,12 @@ export default function ChatPreview({
           'relative flex items-stretch gap-2.5 overflow-hidden py-2 outline-none'
         )}
       >
-        <div className='h-12 w-12 self-center rounded-full bg-background-light sm:h-14 sm:w-14'>
+        <div className='h-12 w-12 self-center overflow-hidden rounded-full bg-background-light dark:bg-white sm:h-14 sm:w-14'>
           {React.isValidElement(image)
             ? image
             : image && (
                 <Image
-                  className='h-full w-full rounded-full'
+                  className='h-full w-full'
                   src={image as string}
                   sizes='150px'
                   width={56}

--- a/src/modules/HomePage/HomePage.tsx
+++ b/src/modules/HomePage/HomePage.tsx
@@ -41,7 +41,7 @@ export default function HomePage({
       asContainer
       onClick={() => sendEvent('click integrate_chat_button')}
       image={
-        <div className='h-full w-full rounded-full bg-background-primary p-3 text-text-on-primary'>
+        <div className='h-full w-full bg-background-primary p-3 text-text-on-primary'>
           <Image src={IntegrateIcon} alt='integrate chat' />
         </div>
       }
@@ -63,7 +63,7 @@ export default function HomePage({
       asContainer
       onClick={() => sendEvent('click launch_community_button')}
       image={
-        <div className='h-full w-full rounded-full bg-background-primary p-4 text-text-on-primary'>
+        <div className='h-full w-full bg-background-primary p-4 text-text-on-primary'>
           <Image src={AddIcon} alt='launch community' />
         </div>
       }


### PR DESCRIPTION
# Other changes
Change the content of the image to not have roundings so the roundings are done by the container with overflow hidden. This makes non-circle images doesn't have a bit of background surrounding it.
![image](https://user-images.githubusercontent.com/53143942/234349062-1357b5d0-9b75-441d-a4b0-adff6b061bfc.png)

For example, in the pic, subsocial image is circle, while moonbeam is not, so the subsocial one has a bit of white circle surrounding it.