### PR TITLE
Enable soft link for posts into space id

### DIFF
--- a/src/constants/chat-room.ts
+++ b/src/constants/chat-room.ts
@@ -1,0 +1,23 @@
+const TOPIC_TO_SPACE_ID_MAP: Record<string, string> = {
+  polka: '1005',
+}
+const SPACE_ID_TO_TOPIC_MAP = Object.entries(TOPIC_TO_SPACE_ID_MAP).reduce(
+  (acc, [topic, roomId]) => {
+    acc[roomId] = topic
+    return acc
+  },
+  {} as Record<string, string>
+)
+export function getTopicFromSpaceId(spaceId: string) {
+  return SPACE_ID_TO_TOPIC_MAP[spaceId] ?? ''
+}
+export function getSpaceIdFromTopic(topic: string) {
+  return TOPIC_TO_SPACE_ID_MAP[topic] ?? ''
+}
+
+const LINKED_POST_IDS_FOR_SPACE_ID: Record<string, string[]> = {
+  '1005': ['754'],
+}
+export function getLinkedPostIdsForSpaceId(spaceId: string) {
+  return LINKED_POST_IDS_FOR_SPACE_ID[spaceId] ?? []
+}

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -1,14 +1,2 @@
 export const CHAT_PER_PAGE = 50
 export const ESTIMATED_ENERGY_FOR_ONE_TX = 100_000_000
-
-export const TOPIC_TO_ROOM_ID_MAP = {
-  polka: '1005',
-} satisfies Record<string, string>
-
-export const ROOM_ID_TO_TOPIC_MAP = Object.entries(TOPIC_TO_ROOM_ID_MAP).reduce(
-  (acc, [topic, roomId]) => {
-    acc[roomId] = topic
-    return acc
-  },
-  {} as Record<string, string>
-)

--- a/src/modules/HomePage/HomePage.tsx
+++ b/src/modules/HomePage/HomePage.tsx
@@ -2,6 +2,7 @@ import AddIcon from '@/assets/icons/add.png'
 import IntegrateIcon from '@/assets/icons/integrate.png'
 import ChatPreview from '@/components/chats/ChatPreview'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
+import { getLinkedPostIdsForSpaceId } from '@/constants/chat-room'
 import useIsInIframe from '@/hooks/useIsInIframe'
 import { getPostQuery } from '@/services/api/query'
 import { getPostIdsBySpaceIdQuery } from '@/services/subsocial/posts'
@@ -11,6 +12,7 @@ import { getIpfsContentUrl } from '@/utils/ipfs'
 import { createSlug } from '@/utils/slug'
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
+import { useMemo } from 'react'
 import useSortedPostIdsByLatestMessage from './hooks/useSortByLatestMessage'
 import useSortByUrlQuery from './hooks/useSortByUrlQuery'
 
@@ -27,8 +29,11 @@ export default function HomePage({
   isMainPage,
 }: HomePageProps) {
   const { data } = getPostIdsBySpaceIdQuery.useQuery(spaceId)
+  const allPostIds = useMemo(() => {
+    return [...(data?.postIds ?? []), ...getLinkedPostIdsForSpaceId(spaceId)]
+  }, [data, spaceId])
 
-  const sortedIds = useSortedPostIdsByLatestMessage(data?.postIds ?? [])
+  const sortedIds = useSortedPostIdsByLatestMessage(allPostIds)
   const order = useSortByUrlQuery(sortedIds)
 
   const sendEvent = useSendEvent()


### PR DESCRIPTION
This way, some space can include posts from other spaces into its home page chat list

Now, space id 1005 is adding post id 754 (polkadot chat) to its home page list

# Related task
https://app.clickup.com/t/865c6zbx4