### PR TITLE
Add object-cover to chat preview images

### DIFF
--- a/src/components/chats/ChatPreview/ChatPreview.tsx
+++ b/src/components/chats/ChatPreview/ChatPreview.tsx
@@ -66,7 +66,7 @@ export default function ChatPreview({
             ? image
             : image && (
                 <Image
-                  className='h-full w-full rounded-full'
+                  className='h-full w-full rounded-full object-cover'
                   src={image as string}
                   sizes='150px'
                   width={56}

--- a/src/modules/_c/ChatPage/ChatPage.tsx
+++ b/src/modules/_c/ChatPage/ChatPage.tsx
@@ -84,7 +84,7 @@ function NavbarChatInfo({
       </div>
       <div className='flex items-center gap-2 overflow-hidden'>
         <Image
-          className='h-9 w-9 justify-self-end rounded-full bg-background-lightest'
+          className='h-9 w-9 justify-self-end rounded-full bg-background-lightest object-cover'
           width={36}
           height={36}
           src={image}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/53143942/234567096-780566b7-5266-40ea-956c-b6cefbf5beee.png)
After:
![image](https://user-images.githubusercontent.com/53143942/234567204-d41c40c8-fdf3-4d51-87df-63996e24098f.png)

