### PR TITLE
Fixed issue with redirecting when have url search param

### DIFF
--- a/src/components/navbar/Navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar/Navbar.tsx
@@ -98,7 +98,7 @@ export default function Navbar({ customContent, ...props }: NavbarProps) {
           ) : (
             <div className='flex items-center justify-between'>
               <Link
-                href={(isInIframe && prevUrl) || getHomePageLink(router.asPath)}
+                href={(isInIframe && prevUrl) || getHomePageLink(router)}
                 aria-label='Back to home'
               >
                 <Logo className='text-2xl' />

--- a/src/modules/_[spaceId]/HomePage/HomePage.tsx
+++ b/src/modules/_[spaceId]/HomePage/HomePage.tsx
@@ -123,7 +123,7 @@ function ChatPreviewContainer({ postId }: { postId: string }) {
       asLink={{
         replace: isInIframe,
         href: getChatPageLink(
-          router.asPath,
+          router,
           createSlug(postId, { title: content?.title })
         ),
       }}

--- a/src/modules/_[spaceId]/_c/ChatPage/ChatPage.tsx
+++ b/src/modules/_[spaceId]/_c/ChatPage/ChatPage.tsx
@@ -77,7 +77,7 @@ function NavbarChatInfo({
       <div className='mr-2 flex w-9 items-center justify-center'>
         <Button
           size='circle'
-          href={prevUrl || getHomePageLink(router.asPath)}
+          href={prevUrl || getHomePageLink(router)}
           nextLinkProps={{ replace: isInIframe }}
           variant='transparent'
         >

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -1,13 +1,16 @@
-function getSpaceIdFromUrl(asPath: string) {
-  return asPath.split('/')[1]
+import { ParsedUrlQuery } from 'querystring'
+
+type CurrentPath = { query: ParsedUrlQuery }
+function getSpaceIdFromUrl(currentPath: CurrentPath) {
+  return currentPath.query.spaceId as string
 }
 
-export function getHomePageLink(asPath: string) {
-  const spaceId = getSpaceIdFromUrl(asPath)
+export function getHomePageLink(currentPath: CurrentPath) {
+  const spaceId = getSpaceIdFromUrl(currentPath)
   return `/${spaceId ?? ''}`
 }
 
-export function getChatPageLink(asPath: string, chatSlug: string) {
-  const spaceId = getSpaceIdFromUrl(asPath)
+export function getChatPageLink(currentPath: CurrentPath, chatSlug: string) {
+  const spaceId = getSpaceIdFromUrl(currentPath)
   return `/${spaceId}/c/${chatSlug}`
 }


### PR DESCRIPTION
# Problem
When having url like `/x?theme=light`, currently it will make the chat href to `/x?theme=light/c/[slug]`

# Solution
Use router query instead of router asPath as data for making the href.