### PR TITLE
Remove color mode toggler if user set the theme from url

### DIFF
--- a/src/components/ColorModeToggler.tsx
+++ b/src/components/ColorModeToggler.tsx
@@ -1,3 +1,4 @@
+import { useConfigContext } from '@/contexts/ConfigContext'
 import useGetTheme from '@/hooks/useGetTheme'
 import { useTheme } from 'next-themes'
 import { useEffect, useState } from 'react'
@@ -10,11 +11,13 @@ export default function ColorModeToggler({ ...props }: ColorModeTogglerProps) {
   const { setTheme } = useTheme()
   const theme = useGetTheme()
   const [mounted, setMounted] = useState(false)
+  const { theme: themeInConfig } = useConfigContext()
+
   useEffect(() => {
     setMounted(true)
   }, [])
 
-  if (!mounted) return null
+  if (!mounted || themeInConfig) return null
 
   const handleClick = (e: any) => {
     setTheme(theme === 'dark' ? 'light' : 'dark')

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -1,11 +1,12 @@
+import { Theme } from '@/@types/theme'
 import { getUrlQuery } from '@/utils/window'
 import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 
-type State = { theme: string | undefined; order: string[] }
+type State = { theme: Theme | undefined; order: string[] }
 const ConfigContext = createContext<State>({ theme: undefined, order: [] })
 
 export function ConfigProvider({ children }: { children: any }) {
-  const [theme, setTheme] = useState<string>()
+  const [theme, setTheme] = useState<Theme>()
   const [order, setOrder] = useState<string[]>([])
 
   useEffect(() => {

--- a/src/hooks/useGetTheme.ts
+++ b/src/hooks/useGetTheme.ts
@@ -1,9 +1,14 @@
 import { Theme } from '@/@types/theme'
+import { useConfigContext } from '@/contexts/ConfigContext'
 import { useTheme } from 'next-themes'
 
 export default function useGetTheme(): Theme | undefined {
   const { theme, systemTheme } = useTheme()
+  const { theme: configTheme } = useConfigContext()
+
+  if (configTheme) return configTheme
   if (theme === undefined) return undefined
+
   const isDark =
     theme === 'dark' || (theme === 'system' && systemTheme === 'dark')
   return isDark ? 'dark' : 'light'

--- a/src/hooks/useRandomColor.ts
+++ b/src/hooks/useRandomColor.ts
@@ -1,4 +1,5 @@
 import { Theme } from '@/@types/theme'
+import { useConfigContext } from '@/contexts/ConfigContext'
 import { generateRandomColor } from '@/utils/random-colors'
 import useGetTheme from './useGetTheme'
 
@@ -6,6 +7,7 @@ export default function useRandomColor(
   seed: string | null | undefined,
   theme?: Theme
 ) {
+  const { theme: currentThemeConfig } = useConfigContext()
   const currentTheme = useGetTheme()
-  return generateRandomColor(seed, theme ?? currentTheme)
+  return generateRandomColor(seed, theme ?? currentThemeConfig ?? currentTheme)
 }


### PR DESCRIPTION
Currently, in sub.id, which sets the theme from url to light, you can still toggle the theme but its not changing the theme