### PR TITLE
Adjust position of toast to always be in top center

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -14,12 +14,13 @@ export default function Toast({ t, icon, title, description }: ToastProps) {
     <Transition
       appear
       show={t.visible}
+      className='relative top-12'
       enter={cx('transition duration-150')}
-      enterFrom={cx('translate-x-6 opacity-0')}
-      enterTo={cx('translate-x-0 opacity-100')}
+      enterFrom={cx('-translate-y-6 opacity-0')}
+      enterTo={cx('translate-y-0 opacity-100')}
       leave={cx('transition duration-150')}
-      leaveFrom={cx('translate-x-0 opacity-100')}
-      leaveTo={cx('translate-x-6 opacity-0')}
+      leaveFrom={cx('translate-y-0 opacity-100')}
+      leaveTo={cx('-translate-y-6 opacity-0')}
     >
       <div
         className={cx(

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,5 @@
 import HeadConfig, { HeadConfigProps } from '@/components/HeadConfig'
 import { ConfigProvider, useConfigContext } from '@/contexts/ConfigContext'
-import useBreakpointThreshold from '@/hooks/useBreakpointThreshold'
 import { QueryProvider } from '@/services/provider'
 import { initAllStores } from '@/stores/utils'
 import '@/styles/globals.css'
@@ -50,6 +49,5 @@ function AppContent({ Component, pageProps }: AppProps<AppCommonProps>) {
 }
 
 function ToasterConfig() {
-  const mdUp = useBreakpointThreshold('md')
-  return <Toaster position={mdUp ? 'bottom-right' : 'top-center'} />
+  return <Toaster position='top-center' />
 }


### PR DESCRIPTION
# Changes
- Previously, in desktop the toast is on bottom right, while in mobile its top center. Now its all in top center
- Add top offset to make the toast is on the bottom of navbar
- Adjust animation so it comes from top rather from right