### PR TITLE
Add chat menu shadow in light mode

### DIFF
--- a/src/components/floating/CommonCustomContextMenu.tsx
+++ b/src/components/floating/CommonCustomContextMenu.tsx
@@ -32,10 +32,7 @@ function CommonContextMenu({ menus, closeMenu }: DefaultContextMenuProps) {
   return (
     <ul className='flex w-52 flex-col overflow-hidden rounded-lg bg-background-light py-1 shadow-[0_5px_50px_-12px_rgb(0,0,0,.25)] dark:shadow-[0_5px_50px_-12px_rgb(0,0,0)]'>
       {menus.map(({ onClick, text, icon }) => (
-        <li
-          className='py-2 px-4 transition focus:bg-background-lighter hover:bg-background-lighter'
-          key={text}
-        >
+        <li key={text}>
           <Button
             onClick={() => {
               onClick()
@@ -43,7 +40,7 @@ function CommonContextMenu({ menus, closeMenu }: DefaultContextMenuProps) {
             }}
             variant='transparent'
             size='noPadding'
-            className='flex w-full items-center gap-4 text-left'
+            className='flex w-full items-center gap-4 rounded-none py-2 px-4 text-left transition focus:bg-background-lighter hover:bg-background-lighter'
             interactive='none'
           >
             {icon}

--- a/src/components/floating/CommonCustomContextMenu.tsx
+++ b/src/components/floating/CommonCustomContextMenu.tsx
@@ -30,7 +30,7 @@ export default function CommonCustomContextMenu({
 
 function CommonContextMenu({ menus, closeMenu }: DefaultContextMenuProps) {
   return (
-    <ul className='flex w-52 flex-col overflow-hidden rounded-lg bg-background-light py-1 shadow-[0_5px_50px_-12px_rgb(0,0,0,.15)] dark:shadow-[0_5px_50px_-12px_rgb(0,0,0)]'>
+    <ul className='flex w-52 flex-col overflow-hidden rounded-lg bg-background-light py-1 shadow-[0_5px_50px_-12px_rgb(0,0,0,.25)] dark:shadow-[0_5px_50px_-12px_rgb(0,0,0)]'>
       {menus.map(({ onClick, text, icon }) => (
         <li
           className='py-2 px-4 transition focus:bg-background-lighter hover:bg-background-lighter'


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/53143942/235455428-bcd0e60a-00db-429a-a520-96fbbac2095b.png)
After:
![image](https://user-images.githubusercontent.com/53143942/235455397-da16ebaa-dc0f-4b2a-8d73-546f59e4cb52.png)

# Other change
Make all part of hoverable context menu item clickable. Now, the edge part of the menu is not clickable
