### PR TITLE
Fix issue with multiple same sub

### DIFF
--- a/src/services/subsocial/commentIds/subscription.ts
+++ b/src/services/subsocial/commentIds/subscription.ts
@@ -107,8 +107,8 @@ export function useSubscribeCommentIdsByPostId(
 
     return () => {
       unsub?.then((func) => func())
-      subscribedPostIds.delete(postId)
       lastIdInPreviousSub.current = undefined
+      if (unsub) subscribedPostIds.delete(postId)
     }
   }, [postId, queryClient, enabled, callbackRef])
 }
@@ -149,9 +149,11 @@ export function useSubscribeCommentIdsByPostIds(
     })
 
     return () => {
-      unsubs.forEach((unsub) => unsub?.then((func) => func()))
-      postIds.forEach((postId) => subscribedPostIds.delete(postId))
       lastIdInPreviousSub.current = {}
+      unsubs.forEach((unsub, idx) => {
+        unsub?.then((func) => func())
+        if (unsub) subscribedPostIds.delete(postIds[idx])
+      })
     }
   }, [postIds, queryClient, enabled, callbackRef])
 }


### PR DESCRIPTION
# Issue
Currently, there is a bug where calling multiple same subscription will still have more than 1 subscription running at the same time.

# Solution
The issue is in the cleanup of the subscription, which makes some effect where the subscription is skipped (because the postId is already subscribed) still removes the subscribedPostIds data when the cleanup is called.
It should only be removed if the current subscribed effect's cleanup is called.