### PR TITLE
Fix Chat Menu Clipped Issue

### DIFF
--- a/src/components/chats/ChatList/ChatList.tsx
+++ b/src/components/chats/ChatList/ChatList.tsx
@@ -160,7 +160,9 @@ function ChatListContent({
             dataLength={loadedComments.length}
             next={loadMore}
             className={cx(
-              'relative flex flex-col-reverse gap-2 !overflow-hidden pb-2'
+              'relative flex flex-col-reverse gap-2 !overflow-hidden pb-2',
+              // need to have enough room to open message menu
+              'min-h-[400px]'
             )}
             hasMore={!isAllCommentsLoaded}
             inverse


### PR DESCRIPTION
# Issue
In chat with only some messages available, the chat container will be so small that the menu inside will be clipped.
![image](https://user-images.githubusercontent.com/53143942/236509272-ca75e1c6-8840-4c92-8e0b-572883da06c8.png)

# Solution
Add min height for chat container. 400px is picked because its small enough that phones won't have extra scrolling and big enough for current menu (+ some, maybe 2 more additional menu down the road if needed)
