### PR TITLE
Make context menu z under modal

### DIFF
--- a/src/components/floating/CustomContextMenu.tsx
+++ b/src/components/floating/CustomContextMenu.tsx
@@ -92,7 +92,7 @@ export default function CustomContextMenu({
         {...getFloatingProps()}
         appear
         show={openMenu}
-        className='z-50 transition-opacity'
+        className='z-30 transition-opacity'
         enter='ease-out duration-150'
         enterFrom='opacity-0'
         enterTo='opacity-100'


### PR DESCRIPTION
# Issue
![image](https://github.com/dappforce/grillchat/assets/53143942/062fc06f-c123-4e76-899a-68a15260f5a9)

# Solution
Put z index of context menu to z-30 instead of z-50 to be under modal which has z-40