### PR TITLE
Fix emoji with skin tone modifier not recognized as emoji only text

### DIFF
--- a/src/components/HeadConfig.tsx
+++ b/src/components/HeadConfig.tsx
@@ -1,3 +1,4 @@
+import { Source_Sans_Pro } from 'next/font/google'
 import Head from 'next/head'
 
 export type HeadConfigProps = {
@@ -6,6 +7,11 @@ export type HeadConfigProps = {
   description?: string | null
   disableZoom?: boolean
 }
+
+const sourceSansPro = Source_Sans_Pro({
+  weight: ['400', '600'],
+  subsets: ['latin'],
+})
 
 const LIMIT = 45
 function summarize(text: string) {
@@ -43,6 +49,11 @@ export default function HeadConfig({
       ) : (
         <meta name='viewport' content='width=device-width, initial-scale=1' />
       )}
+      <style jsx global>{`
+        html {
+          --source-sans-pro: ${sourceSansPro.style.fontFamily};
+        }
+      `}</style>
       <link rel='icon' href='/favicon.ico' />
       <link
         rel='apple-touch-icon'

--- a/src/components/HeadConfig.tsx
+++ b/src/components/HeadConfig.tsx
@@ -1,4 +1,3 @@
-import { Source_Sans_Pro } from 'next/font/google'
 import Head from 'next/head'
 
 export type HeadConfigProps = {
@@ -7,11 +6,6 @@ export type HeadConfigProps = {
   description?: string | null
   disableZoom?: boolean
 }
-
-const sourceSansPro = Source_Sans_Pro({
-  weight: ['400', '600'],
-  subsets: ['latin'],
-})
 
 const LIMIT = 45
 function summarize(text: string) {
@@ -49,11 +43,6 @@ export default function HeadConfig({
       ) : (
         <meta name='viewport' content='width=device-width, initial-scale=1' />
       )}
-      <style jsx global>{`
-        html {
-          --source-sans-pro: ${sourceSansPro.style.fontFamily};
-        }
-      `}</style>
       <link rel='icon' href='/favicon.ico' />
       <link
         rel='apple-touch-icon'

--- a/src/components/chats/ChatItem/ChatItem.tsx
+++ b/src/components/chats/ChatItem/ChatItem.tsx
@@ -141,10 +141,9 @@ export default function ChatItem({
   }
 
   const isEmojiOnly = shouldRenderEmojiChatItem(body)
+  const ChatItemContentVariant = isEmojiOnly ? EmojiChatItem : DefaultChatItem
 
   const relativeTime = getTimeRelativeToNow(createdAtTime)
-
-  const ChatItemContentVariant = isEmojiOnly ? EmojiChatItem : DefaultChatItem
 
   return (
     <div

--- a/src/components/layouts/DefaultLayout.tsx
+++ b/src/components/layouts/DefaultLayout.tsx
@@ -1,18 +1,12 @@
 import LinkText from '@/components/LinkText'
 import { useLocation } from '@/stores/location'
 import { cx } from '@/utils/class-names'
-import { Source_Sans_Pro } from 'next/font/google'
 import { ComponentProps } from 'react'
 import { HiOutlineChevronLeft } from 'react-icons/hi2'
 import useBreakpointThreshold from '../../hooks/useBreakpointThreshold'
 import Button from '../Button'
 import Navbar, { NavbarProps } from '../navbar/Navbar'
 import NavbarExtension from '../navbar/NavbarExtension'
-
-const sourceSansPro = Source_Sans_Pro({
-  weight: ['400', '600'],
-  subsets: ['latin'],
-})
 
 export type DefaultLayoutProps = ComponentProps<'div'> & {
   navbarProps?: NavbarProps
@@ -27,10 +21,7 @@ export default function DefaultLayout({
 }: DefaultLayoutProps) {
   return (
     <div
-      className={cx(
-        'flex h-screen flex-col bg-background text-text',
-        sourceSansPro.className
-      )}
+      className={cx('flex h-screen flex-col bg-background text-text')}
       style={{ height: '100svh' }}
       {...props}
     >

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,9 +3,11 @@ import { ConfigProvider, useConfigContext } from '@/contexts/ConfigContext'
 import { QueryProvider } from '@/services/provider'
 import { initAllStores } from '@/stores/utils'
 import '@/styles/globals.css'
+import { cx } from '@/utils/class-names'
 import { getGaId } from '@/utils/env/client'
 import { ThemeProvider } from 'next-themes'
 import type { AppProps } from 'next/app'
+import { Source_Sans_Pro } from 'next/font/google'
 import { GoogleAnalytics } from 'nextjs-google-analytics'
 import NextNProgress from 'nextjs-progressbar'
 import { useEffect, useRef } from 'react'
@@ -15,6 +17,12 @@ export type AppCommonProps = {
   head?: HeadConfigProps
   dehydratedState?: any
 }
+
+const sourceSansPro = Source_Sans_Pro({
+  weight: ['400', '600'],
+  subsets: ['latin'],
+  variable: '--source-sans-pro',
+})
 
 export default function App(props: AppProps<AppCommonProps>) {
   return (
@@ -42,7 +50,9 @@ function AppContent({ Component, pageProps }: AppProps<AppCommonProps>) {
         <NextNProgress color='#4d46dc' />
         <HeadConfig {...head} />
         <GoogleAnalytics trackPageViews gaMeasurementId={getGaId()} />
-        <Component {...props} />
+        <div className={cx(sourceSansPro.variable, 'font-sans')}>
+          <Component {...props} />
+        </div>
       </QueryProvider>
     </ThemeProvider>
   )

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,7 +7,6 @@ import { cx } from '@/utils/class-names'
 import { getGaId } from '@/utils/env/client'
 import { ThemeProvider } from 'next-themes'
 import type { AppProps } from 'next/app'
-import { Source_Sans_Pro } from 'next/font/google'
 import { GoogleAnalytics } from 'nextjs-google-analytics'
 import NextNProgress from 'nextjs-progressbar'
 import { useEffect, useRef } from 'react'
@@ -17,12 +16,6 @@ export type AppCommonProps = {
   head?: HeadConfigProps
   dehydratedState?: any
 }
-
-const sourceSansPro = Source_Sans_Pro({
-  weight: ['400', '600'],
-  subsets: ['latin'],
-  variable: '--source-sans-pro',
-})
 
 export default function App(props: AppProps<AppCommonProps>) {
   return (
@@ -50,7 +43,7 @@ function AppContent({ Component, pageProps }: AppProps<AppCommonProps>) {
         <NextNProgress color='#4d46dc' />
         <HeadConfig {...head} />
         <GoogleAnalytics trackPageViews gaMeasurementId={getGaId()} />
-        <div className={cx(sourceSansPro.variable, 'font-sans')}>
+        <div className={cx('font-sans')}>
           <Component {...props} />
         </div>
       </QueryProvider>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import { cx } from '@/utils/class-names'
 import { getGaId } from '@/utils/env/client'
 import { ThemeProvider } from 'next-themes'
 import type { AppProps } from 'next/app'
+import { Source_Sans_Pro } from 'next/font/google'
 import { GoogleAnalytics } from 'nextjs-google-analytics'
 import NextNProgress from 'nextjs-progressbar'
 import { useEffect, useRef } from 'react'
@@ -17,9 +18,19 @@ export type AppCommonProps = {
   dehydratedState?: any
 }
 
+const sourceSansPro = Source_Sans_Pro({
+  weight: ['400', '600'],
+  subsets: ['latin'],
+})
+
 export default function App(props: AppProps<AppCommonProps>) {
   return (
     <ConfigProvider>
+      <style jsx global>{`
+        html {
+          --source-sans-pro: ${sourceSansPro.style.fontFamily};
+        }
+      `}</style>
       <AppContent {...props} />
     </ConfigProvider>
   )

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -8,7 +8,8 @@ export function copyToClipboard(text: string) {
   navigator.clipboard.writeText(text)
 }
 
-const EMOJI_REGEX = /\p{Extended_Pictographic}/gu
+const EMOJI_REGEX =
+  /(?![*#0-9]+)[\p{Emoji}\p{Emoji_Modifier}\p{Emoji_Component}\p{Emoji_Modifier_Base}\p{Emoji_Presentation}]/gu
 export function isTextContainsOnlyEmoji(text: string) {
   const isOnlyEmoji = text.replace(EMOJI_REGEX, '').trim().length === 0
   return isOnlyEmoji

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Source Sans Pro', ...defaultTheme.fontFamily.sans],
+        sans: ['var(--source-sans-pro)', ...defaultTheme.fontFamily.sans],
       },
       colors: {
         background: 'rgb(var(--background) / <alpha-value>)',


### PR DESCRIPTION
# Issue
![image](https://github.com/dappforce/grillchat/assets/53143942/93c1405b-481a-4b63-8638-6eb47ef92b45)

# Solution
Update the emoji regex to include skin tone checker

## Other Change
- Move loading font from `DefaultLayout` to `_app` to use style in html, so the variable will exists outside of div (e.g. modal with react portal)