### PR TITLE
Fix Message Link

### DIFF
--- a/src/components/chats/ChatList/ChatList.tsx
+++ b/src/components/chats/ChatList/ChatList.tsx
@@ -125,6 +125,7 @@ function ChatListContent({
     }
 
     replaceUrl(urlJoin(getChatPageLink(router), `/${messageId}`))
+    setMessageModalMsgId(messageId)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rawMessageIds, hasScrolledToMessageRef])
 

--- a/src/components/chats/ChatList/ChatList.tsx
+++ b/src/components/chats/ChatList/ChatList.tsx
@@ -11,7 +11,6 @@ import { cx } from '@/utils/class-names'
 import { getCurrentUrlWithoutQuery, getUrlQuery } from '@/utils/links'
 import { isValidNumber } from '@/utils/strings'
 import { replaceUrl } from '@/utils/window'
-import { useRouter } from 'next/router'
 import {
   ComponentProps,
   Fragment,
@@ -61,7 +60,6 @@ function ChatListContent({
   newMessageNoticeClassName,
   ...props
 }: ChatListProps) {
-  const router = useRouter()
   const lastReadId = useFocusedLastMessageId(chatId)
 
   const scrollableContainerId = useId()

--- a/src/components/chats/ChatList/ChatList.tsx
+++ b/src/components/chats/ChatList/ChatList.tsx
@@ -10,6 +10,7 @@ import { useMyAccount } from '@/stores/my-account'
 import { cx } from '@/utils/class-names'
 import { getCurrentUrlWithoutQuery, getUrlQuery } from '@/utils/links'
 import { isValidNumber } from '@/utils/strings'
+import { replaceUrl } from '@/utils/window'
 import { useRouter } from 'next/router'
 import {
   ComponentProps,
@@ -119,9 +120,7 @@ function ChatListContent({
         return
       }
 
-      router.replace(getCurrentUrlWithoutQuery(), undefined, {
-        shallow: true,
-      })
+      replaceUrl(getCurrentUrlWithoutQuery())
       await scrollToChatElement(messageId)
     })()
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/chats/ChatList/ChatList.tsx
+++ b/src/components/chats/ChatList/ChatList.tsx
@@ -97,7 +97,7 @@ function ChatListContent({
     innerContainer: innerRef,
   })
 
-  const scrollToChatElement = useScrollToMessage(
+  const scrollToMessage = useScrollToMessage(
     scrollContainerRef,
     {
       messageIds: currentPageMessageIds,
@@ -123,7 +123,7 @@ function ChatListContent({
     if (!isMessageIdsFetched) return
 
     if (!messageId || !isValidNumber(messageId)) {
-      scrollToChatElement(lastReadId ?? '', false)
+      scrollToMessage(lastReadId ?? '', false)
       return
     }
 
@@ -203,7 +203,7 @@ function ChatListContent({
                   message={message}
                   key={message.id}
                   messageBubbleId={getMessageElementId(message.id)}
-                  scrollToMessage={scrollToChatElement}
+                  scrollToMessage={scrollToMessage}
                 />
               )
               if (!showLastUnreadMessageNotice) return chatElement
@@ -224,6 +224,7 @@ function ChatListContent({
         isOpen={!!messageModalMsgId}
         closeModal={() => setMessageModalMsgId('')}
         messageId={messageModalMsgId}
+        scrollToMessage={scrollToMessage}
       />
       <NewMessageNotice
         className={cx('absolute bottom-0 right-6', newMessageNoticeClassName)}

--- a/src/components/chats/ChatList/ChatList.tsx
+++ b/src/components/chats/ChatList/ChatList.tsx
@@ -4,6 +4,7 @@ import MessageModal from '@/components/modals/MessageModal'
 import ScrollableContainer from '@/components/ScrollableContainer'
 import { CHAT_PER_PAGE } from '@/constants/chat'
 import useFilterBlockedMessageIds from '@/hooks/useFilterBlockedMessageIds'
+import usePrevious from '@/hooks/usePrevious'
 import useWrapInRef from '@/hooks/useWrapInRef'
 import { getPostQuery } from '@/services/api/query'
 import { useCommentIdsByPostId } from '@/services/subsocial/commentIds'
@@ -66,6 +67,7 @@ function ChatListContent({
   const router = useRouter()
   const lastReadId = useFocusedLastMessageId(chatId)
   const [messageModalMsgId, setMessageModalMsgId] = useState('')
+  const prevMessageModalMsgId = usePrevious(messageModalMsgId)
 
   const scrollableContainerId = useId()
   const innerScrollContainerRef = useRef<HTMLDivElement>(null)
@@ -109,6 +111,7 @@ function ChatListContent({
     }
   )
 
+  // TODO: refactor this by putting the url query getter logic to ChatPage
   const hasScrolledToMessageRef = useRef(false)
   useEffect(() => {
     if (hasScrolledToMessageRef.current) return
@@ -124,10 +127,18 @@ function ChatListContent({
       return
     }
 
-    replaceUrl(urlJoin(getChatPageLink(router), `/${messageId}`))
     setMessageModalMsgId(messageId)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rawMessageIds, hasScrolledToMessageRef])
+
+  useEffect(() => {
+    if (messageModalMsgId) {
+      replaceUrl(urlJoin(getChatPageLink(router), `/${messageModalMsgId}`))
+    } else if (prevMessageModalMsgId && !messageModalMsgId) {
+      replaceUrl(getChatPageLink(router))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prevMessageModalMsgId, messageModalMsgId])
 
   const isAtBottomRef = useWrapInRef(isAtBottom)
   useEffect(() => {

--- a/src/components/chats/ChatList/hooks/useGetChatElement.ts
+++ b/src/components/chats/ChatList/hooks/useGetChatElement.ts
@@ -68,16 +68,17 @@ export default function useGetMessageElement({
     const element = document.getElementById(elementId)
     if (element) return element
 
-    const isMessageIdIncluded = messageIds.includes(messageId)
-    if (!isMessageIdIncluded) {
-      await loadMoreUntilMessageIsLoaded(messageId)
-    }
     const { resolvers, waitingMessageIds } = promiseRef.current
     if (!resolvers.get(messageId)) {
       resolvers.set(messageId, [])
     }
     resolvers.get(messageId)?.push(getResolver())
     waitingMessageIds.add(messageId)
+
+    const isMessageIdIncluded = messageIds.includes(messageId)
+    if (!isMessageIdIncluded) {
+      await loadMoreUntilMessageIsLoaded(messageId)
+    }
     await getPromise()
     await waitAllMessagesLoadedRef.current()
 

--- a/src/components/modals/MessageModal.tsx
+++ b/src/components/modals/MessageModal.tsx
@@ -45,7 +45,7 @@ export default function MessageModal({
     >
       <div
         className={cx(
-          'rounded-2xl bg-background p-4',
+          'max-h-96 overflow-y-auto rounded-2xl bg-background p-4',
           !message && 'h-28 animate-pulse'
         )}
       >

--- a/src/components/modals/MessageModal.tsx
+++ b/src/components/modals/MessageModal.tsx
@@ -1,0 +1,40 @@
+import { getPostQuery } from '@/services/api/query'
+import { cx } from '@/utils/class-names'
+import { CommentData } from '@subsocial/api/types'
+import ChatItem from '../chats/ChatItem'
+import Modal, { ModalFunctionalityProps } from './Modal'
+
+export type MessageModalProps = ModalFunctionalityProps & {
+  messageId: string
+}
+
+export default function MessageModal({
+  messageId,
+  ...props
+}: MessageModalProps) {
+  const { data: message } = getPostQuery.useQuery(messageId)
+  const chatId = (message as unknown as CommentData)?.struct.rootPostId
+  const { data: chat } = getPostQuery.useQuery(chatId)
+
+  const chatTitle = chat?.content?.title || (
+    <span className='ml-2 inline-block h-[1.3em] w-28 animate-pulse rounded-lg bg-background' />
+  )
+
+  return (
+    <Modal
+      {...props}
+      title={
+        <span className='flex items-center'>Message from {chatTitle}</span>
+      }
+    >
+      <div
+        className={cx(
+          'rounded-2xl bg-background p-4',
+          !message && 'h-28 animate-pulse'
+        )}
+      >
+        {message && <ChatItem isMyMessage={false} message={message} />}
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/modals/MessageModal.tsx
+++ b/src/components/modals/MessageModal.tsx
@@ -1,24 +1,40 @@
 import { getPostQuery } from '@/services/api/query'
 import { cx } from '@/utils/class-names'
 import { CommentData } from '@subsocial/api/types'
+import { useState } from 'react'
+import Button from '../Button'
 import ChatItem from '../chats/ChatItem'
 import Modal, { ModalFunctionalityProps } from './Modal'
 
 export type MessageModalProps = ModalFunctionalityProps & {
   messageId: string
+  scrollToMessage?: (messageId: string) => Promise<void>
 }
 
 export default function MessageModal({
   messageId,
+  scrollToMessage,
   ...props
 }: MessageModalProps) {
   const { data: message } = getPostQuery.useQuery(messageId)
   const chatId = (message as unknown as CommentData)?.struct.rootPostId
   const { data: chat } = getPostQuery.useQuery(chatId)
 
+  const [isScrolling, setIsScrolling] = useState(false)
+
   const chatTitle = chat?.content?.title || (
     <span className='ml-2 inline-block h-[1.3em] w-28 animate-pulse rounded-lg bg-background' />
   )
+
+  const handleScrollToMessage = async () => {
+    if (!scrollToMessage) return
+
+    setIsScrolling(true)
+    await scrollToMessage(messageId)
+    setIsScrolling(false)
+
+    props.closeModal()
+  }
 
   return (
     <Modal
@@ -35,6 +51,17 @@ export default function MessageModal({
       >
         {message && <ChatItem isMyMessage={false} message={message} />}
       </div>
+      {scrollToMessage && (
+        <Button
+          isLoading={isScrolling}
+          onClick={handleScrollToMessage}
+          className={cx('mt-6')}
+          size='lg'
+          variant='primary'
+        >
+          Go to message
+        </Button>
+      )}
     </Modal>
   )
 }

--- a/src/components/navbar/Navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar/Navbar.tsx
@@ -112,7 +112,7 @@ export default function Navbar({ customContent, ...props }: NavbarProps) {
         )}
       >
         <Container
-          className={cx('grid h-14 items-center py-2', props.className)}
+          className={cx('grid h-14 items-center py-1.5', props.className)}
         >
           {customContent ? (
             customContent({

--- a/src/modules/chat/ChatPage/ChatPage.tsx
+++ b/src/modules/chat/ChatPage/ChatPage.tsx
@@ -3,6 +3,7 @@ import ChatRoom from '@/components/chats/ChatRoom'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
 import { useConfigContext } from '@/contexts/ConfigContext'
 import useLastReadMessageId from '@/hooks/useLastReadMessageId'
+import usePrevious from '@/hooks/usePrevious'
 import useWrapInRef from '@/hooks/useWrapInRef'
 import { getPostQuery } from '@/services/api/query'
 import { useCommentIdsByPostId } from '@/services/subsocial/commentIds'
@@ -88,6 +89,7 @@ function NavbarChatInfo({
   backButton: JSX.Element
 }) {
   const [isOpenAboutChatModal, setIsOpenAboutChatModal] = useState(false)
+  const prevIsOpenAboutChatModal = usePrevious(isOpenAboutChatModal)
   const router = useRouter()
   const { isChatRoomOnly } = useConfigContext()
 
@@ -102,10 +104,10 @@ function NavbarChatInfo({
     const baseUrl = getChatPageLink(routerRef.current)
     if (isOpenAboutChatModal) {
       replaceUrl(urlJoin(baseUrl, '/about'))
-    } else {
+    } else if (!isOpenAboutChatModal && prevIsOpenAboutChatModal) {
       replaceUrl(baseUrl)
     }
-  }, [isOpenAboutChatModal, routerRef])
+  }, [isOpenAboutChatModal, prevIsOpenAboutChatModal, routerRef])
 
   useEffect(() => {
     const open = getUrlQuery('open')

--- a/src/modules/chat/ChatPage/ChatPageNavbarExtension.tsx
+++ b/src/modules/chat/ChatPage/ChatPageNavbarExtension.tsx
@@ -15,7 +15,7 @@ export default function ChatPageNavbarExtension() {
   if (shouldSendMessageWithoutCaptcha) return null
 
   return (
-    <NavbarExtension className={cx('py-2 sm:py-4')}>
+    <NavbarExtension className={cx('py-2 sm:py-2.5')}>
       <CaptchaTermsAndService className='text-center' />
     </NavbarExtension>
   )


### PR DESCRIPTION
# Issue
- Previous implementation of scroll to message has a bug where for historical data, some promise won't resolve, making it doesn't scroll at all.
- For historical data, the message have to be loaded first before it can scroll, so currently user have to wait while its loading, and there is no indication of loading.

# Solution
- Fix the scrolling bug in [this commit](https://github.com/dappforce/grillchat/commit/aea50cfd3c6d2690d17c28711cff16e7fbc39b86)
- Add message modal with the scroll to message button. When its loading, the button will show that its loading.

## Other Change
- When the message modal showing, the url will change to `/slug/messageId`, and when its closed, it will go back to `/slug`