### PR TITLE
Fix default back link in chat page

### DIFF
--- a/src/components/navbar/Navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar/Navbar.tsx
@@ -6,7 +6,7 @@ import Logo from '@/components/Logo'
 import usePrevious from '@/hooks/usePrevious'
 import { useMyAccount } from '@/stores/my-account'
 import { cx } from '@/utils/class-names'
-import { getChatPageLink, getHomePageLink } from '@/utils/links'
+import { getHomePageLink } from '@/utils/links'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -21,6 +21,7 @@ const LoginModal = dynamic(() => import('@/components/modals/LoginModal'), {
 })
 
 export type NavbarProps = ComponentProps<'div'> & {
+  defaultBackLink?: string
   customContent?: (elements: {
     logoLink: JSX.Element
     authComponent: JSX.Element
@@ -29,7 +30,11 @@ export type NavbarProps = ComponentProps<'div'> & {
   }) => JSX.Element
 }
 
-export default function Navbar({ customContent, ...props }: NavbarProps) {
+export default function Navbar({
+  customContent,
+  defaultBackLink,
+  ...props
+}: NavbarProps) {
   const isInitialized = useMyAccount((state) => state.isInitialized)
   const isInitializedAddress = useMyAccount(
     (state) => state.isInitializedAddress
@@ -93,7 +98,7 @@ export default function Navbar({ customContent, ...props }: NavbarProps) {
   const backButton = (
     <div className='mr-2 flex w-9 items-center justify-center'>
       <BackButton
-        defaultBackLink={getChatPageLink(router)}
+        defaultBackLink={defaultBackLink ?? '/'}
         size='circle'
         variant='transparent'
       >

--- a/src/modules/chat/ChatPage/ChatPage.tsx
+++ b/src/modules/chat/ChatPage/ChatPage.tsx
@@ -11,6 +11,7 @@ import { getIpfsContentUrl } from '@/utils/ipfs'
 import {
   getChatPageLink,
   getCurrentUrlWithoutQuery,
+  getHomePageLink,
   getUrlQuery,
 } from '@/utils/links'
 import { replaceUrl } from '@/utils/window'
@@ -31,6 +32,7 @@ const AboutChatModal = dynamic(
 
 export type ChatPageProps = { chatId: string }
 export default function ChatPage({ chatId }: ChatPageProps) {
+  const router = useRouter()
   const { data: chat } = getPostQuery.useQuery(chatId)
   const { data: messageIds } = useCommentIdsByPostId(chatId, {
     subscribe: true,
@@ -50,6 +52,7 @@ export default function ChatPage({ chatId }: ChatPageProps) {
     <DefaultLayout
       withFixedHeight
       navbarProps={{
+        defaultBackLink: getHomePageLink(router),
         customContent: ({ backButton, authComponent, colorModeToggler }) => (
           <div className='flex items-center justify-between gap-4'>
             <NavbarChatInfo


### PR DESCRIPTION
Currently, there is a bug in chat page where if you open the chat page directly, the back will redirect to the same page