### PR TITLE
Make scrollbar always appear

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -46,6 +46,9 @@
 * {
   @apply scrollbar-thin scrollbar-track-background scrollbar-thumb-background-lightest scrollbar-track-rounded-full scrollbar-thumb-rounded-full dark:scrollbar-thumb-background-lighter;
 }
+body {
+  overflow-y: scroll;
+}
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
# Issue
Content jumps around a bit when the scrollbar appear/disappear, especially when searching in home page.

# Solution
Make scrollbar always appear whether needed or not.
The drawback is, there will always be empty space in the right for the scrollbar gutter.
![image](https://github.com/dappforce/grillchat/assets/53143942/d891ca9b-2fcd-49c8-a8bf-7363f02e69ef)
