### PR TITLE
Use usual link instead of router back for iframe navigation

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -18,9 +18,10 @@ export default function BackButton({
   const router = useRouter()
 
   const hasBackToCurrentSession = !!prevUrl
-  const buttonProps: ButtonProps = hasBackToCurrentSession
-    ? { onClick: () => router.back() }
-    : { href: defaultBackLink, nextLinkProps: { replace: isInIframe } }
+  const buttonProps: ButtonProps =
+    hasBackToCurrentSession && !isInIframe
+      ? { onClick: () => router.back() }
+      : { href: defaultBackLink, nextLinkProps: { replace: isInIframe } }
 
   return (
     <Button


### PR DESCRIPTION
# Issue
Because in iframe, we use router `replace` instead of `push`, when router back was called, the history stack have nothing, so it maybe pops the parent window state, making either the back won't work, or the parent's back is called instead

# Solution
Using usual href instead of router back for iframe

## Drawback
Currently, it will make the scroll restoration won't work in iframe. 