### PR TITLE
Remove custom menu in message modal

### DIFF
--- a/src/components/floating/CommonCustomContextMenu.tsx
+++ b/src/components/floating/CommonCustomContextMenu.tsx
@@ -1,25 +1,34 @@
 import Button from '../Button'
 import CustomContextMenu, { CustomContextMenuProps } from './CustomContextMenu'
 
-type DefaultContextMenuProps = {
-  menus: { text: string; icon?: React.ReactNode; onClick: () => void }[]
+export type CommonContextMenu = {
+  text: string
+  icon?: React.ReactNode
+  onClick: () => void
+}
+type CommonContextMenuItemProps = {
+  menus: CommonContextMenu[]
   closeMenu: () => void
 }
 export type CommonCustomContextMenuProps = Omit<
   CustomContextMenuProps,
   'menuPanel'
 > &
-  Omit<DefaultContextMenuProps, 'closeMenu'>
+  Omit<CommonContextMenuItemProps, 'closeMenu'>
 
 export default function CommonCustomContextMenu({
   children,
   allowedPlacements,
   ...props
 }: CommonCustomContextMenuProps) {
+  if (props.menus.length === 0) {
+    return children()
+  }
+
   return (
     <CustomContextMenu
       menuPanel={(closeMenu) => (
-        <CommonContextMenu closeMenu={closeMenu} {...props} />
+        <CommonContextMenuItem closeMenu={closeMenu} {...props} />
       )}
       allowedPlacements={allowedPlacements}
     >
@@ -28,7 +37,10 @@ export default function CommonCustomContextMenu({
   )
 }
 
-function CommonContextMenu({ menus, closeMenu }: DefaultContextMenuProps) {
+function CommonContextMenuItem({
+  menus,
+  closeMenu,
+}: CommonContextMenuItemProps) {
   return (
     <ul className='flex w-52 flex-col overflow-hidden rounded-lg bg-background-light py-1 shadow-[0_5px_50px_-12px_rgb(0,0,0,.25)] dark:shadow-[0_5px_50px_-12px_rgb(0,0,0)]'>
       {menus.map(({ onClick, text, icon }) => (

--- a/src/components/floating/CustomContextMenu.tsx
+++ b/src/components/floating/CustomContextMenu.tsx
@@ -12,11 +12,11 @@ import { MouseEvent, MouseEventHandler, useState } from 'react'
 
 type ReferenceProps = Record<string, unknown>
 export type CustomContextMenuProps = {
-  children: (
-    toggleMenu: () => void,
-    onContextMenu: MouseEventHandler<Element>,
+  children: (config?: {
+    toggleMenu: () => void
+    onContextMenu: MouseEventHandler<Element>
     referenceProps: ReferenceProps
-  ) => React.ReactNode
+  }) => JSX.Element
   menuPanel: (closeMenu: () => void) => React.ReactNode
   allowedPlacements?: Placement[]
 }
@@ -73,15 +73,15 @@ export default function CustomContextMenu({
 
   return (
     <>
-      {children(
+      {children({
         toggleMenu,
         onContextMenu,
-        getReferenceProps({
+        referenceProps: getReferenceProps({
           ref: refs.setReference,
           ...getReferenceProps(),
           onClick: onReferenceClick,
-        })
-      )}
+        }),
+      })}
       <Transition
         ref={refs.setFloating}
         style={{

--- a/src/components/modals/MessageModal.tsx
+++ b/src/components/modals/MessageModal.tsx
@@ -49,7 +49,13 @@ export default function MessageModal({
           !message && 'h-28 animate-pulse'
         )}
       >
-        {message && <ChatItem isMyMessage={false} message={message} />}
+        {message && (
+          <ChatItem
+            withCustomMenu={false}
+            isMyMessage={false}
+            message={message}
+          />
+        )}
       </div>
       {scrollToMessage && (
         <Button

--- a/src/components/modals/MessageModal.tsx
+++ b/src/components/modals/MessageModal.tsx
@@ -65,7 +65,7 @@ export default function MessageModal({
           size='lg'
           variant='primary'
         >
-          Go to message
+          Scroll to message
         </Button>
       )}
     </Modal>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -46,7 +46,7 @@
 * {
   @apply scrollbar-thin scrollbar-track-background scrollbar-thumb-background-lightest scrollbar-track-rounded-full scrollbar-thumb-rounded-full dark:scrollbar-thumb-background-lighter;
 }
-body {
+html {
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
# Issue
Currently, the chat custom menu will be cropped, and the reply button also don't work.
![image](https://github.com/dappforce/grillchat/assets/53143942/e91ff422-3d0e-44e7-958a-a3425c8ef995)

# Solution
I remove the custom menu in the message modal, so if the user wants to reply or any other thing, they can "scroll to message" first
