### PR TITLE
Fix issue with modal moving when closed

### DIFF
--- a/src/components/modals/Modal.tsx
+++ b/src/components/modals/Modal.tsx
@@ -80,7 +80,7 @@ export default function Modal({
           <div className='fixed inset-0 bg-black bg-opacity-25 backdrop-blur-sm' />
         </Transition.Child>
 
-        <div className='fixed inset-0 overflow-y-auto'>
+        <div className='fixed inset-0 w-screen overflow-y-auto'>
           <div className='flex min-h-full items-center justify-center p-4 text-center'>
             <Transition.Child
               as={Fragment}
@@ -123,7 +123,7 @@ export default function Modal({
                           <Button
                             size='circle'
                             variant='transparent'
-                            className='mr-2 -ml-2 text-lg'
+                            className='-ml-2 mr-2 text-lg'
                             onClick={onBackClick}
                           >
                             <HiOutlineChevronLeft />


### PR DESCRIPTION
# Issue
Currently, when you close modal, the modal will shift/jumps to the left a bit before animating the close animation.
This issue is because of html scrollbar offset. When the modal opens, the scrollbar becomes none.

# Solution
Make modal container have 100vw width which doesn't matter whether the scrollbar is there or not.