### PR TITLE
Improve Rendering in Iframe

### DIFF
--- a/integration/index.ts
+++ b/integration/index.ts
@@ -106,7 +106,21 @@ const grill = {
     this.instance?.remove()
 
     this.instance = iframe
+
+    iframe.style.opacity = '0'
+    iframe.style.transition = 'opacity 0.15s ease-in-out'
+    window.onmessage = (event) => {
+      if (event.data === 'grill:ready') {
+        iframe.style.opacity = '1'
+      }
+    }
+
     widgetElement.appendChild(iframe)
+
+    // fallback if the message is not received
+    setTimeout(() => {
+      iframe.style.opacity = '1'
+    }, 1000)
   },
 }
 

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -19,6 +19,7 @@ export function ConfigProvider({ children }: { children: any }) {
 
   useEffect(() => {
     setState(getConfig())
+    window.top?.postMessage('grill:ready', '*')
   }, [])
 
   return (


### PR DESCRIPTION
# Issue
Currently, in iframe, if the dev sets config like light theme or order, it will have some flickering in the first render, because the first render and the next render after the config is initialized is different.

# Solution
Set the iframe opacity to 0, and only update it to 1 if the widget sends message `grill:ready` to the parent window.