### PR TITLE
Add await for isEnoughBalance call

### DIFF
--- a/src/pages/api/request-token.ts
+++ b/src/pages/api/request-token.ts
@@ -67,7 +67,8 @@ async function verifyCaptcha(captchaToken: string) {
 async function sendToken(address: string) {
   const signer = await getServerAccount()
   if (!signer) throw new Error('Invalid Mnemonic')
-  if (!isEnoughBalance()) throw new Error('Account balance is not enough')
+  if (!(await isEnoughBalance()))
+    throw new Error('Account balance is not enough')
 
   const subsocialApi = await getSubsocialApi()
   const substrateApi = await subsocialApi.substrateApi


### PR DESCRIPTION
# Issue
Currently isEnoughBalance has no use, because it's not awaiting the data, so it will always pass.