### PR TITLE
Improve typing for channel type resource

### DIFF
--- a/integration/tests/integration.test.tsx
+++ b/integration/tests/integration.test.tsx
@@ -43,7 +43,7 @@ describe('Resource Linking Unit', () => {
 
     expect(document.getElementById('grill')?.id).toEqual('grill')
 
-    const configResource: GrillConfig<SocialResource> = {
+    const configResource: GrillConfig = {
       widgetElementId: 'grill',
       hub: { id: '1002' },
       channel: {
@@ -70,7 +70,6 @@ describe('Resource Linking Unit', () => {
       },
     }
 
-    // @ts-ignore
     grill.init(configResource)
 
     expect(document.getElementsByTagName('iframe')?.item(0)?.src).toEqual(


### PR DESCRIPTION
with this typings, `ts-ignore` are not needed, and for the users, they can have correct typings as long as they put the type first.
so for example,
```
grill.init({
  type: 'channel',
  ... // the autocompletes here will only allow you to have the channel's params
})
// works as well for resource type
```