### PR TITLE
Remove chat menus if not sent yet

### DIFF
--- a/src/components/chats/ChatItem/ChatItem.tsx
+++ b/src/components/chats/ChatItem/ChatItem.tsx
@@ -119,7 +119,7 @@ export default function ChatItem({
       },
     ]
   }
-  const menus = withCustomMenu ? getChatMenus() : []
+  const menus = withCustomMenu && isSent ? getChatMenus() : []
 
   if (!body) return null
 


### PR DESCRIPTION
Currently, if message is not sent yet, you can still right click to open custom menu, and open metadata, which will be like this
![image](https://github.com/dappforce/grillchat/assets/53143942/e37b8dac-399b-40ab-a01d-9b1902d7d1c7)
