### PR TITLE
Add parent query from grill-widget and use it in analytic

### DIFF
--- a/integration/index.ts
+++ b/integration/index.ts
@@ -1,4 +1,5 @@
 type QueryParams = {
+  parent?: string
   order?: string
   theme?: string
   resourceId?: string
@@ -126,6 +127,7 @@ const grill = {
 
     const query = new QueryParamsBuilder()
 
+    query.set('parent', window.location.origin)
     if (mergedConfig.order) query.set('order', mergedConfig.order.join(','))
     if (mergedConfig.theme) query.set('theme', mergedConfig.theme)
 


### PR DESCRIPTION
# Issue
Can't access `window.parent.location.origin` from inside iframe, so need to insert the parent origin to the url and read it from there.