### PR TITLE
Fix issue with waiting balance when already have it

### DIFF
--- a/src/hooks/useWaitHasEnergy.ts
+++ b/src/hooks/useWaitHasEnergy.ts
@@ -7,27 +7,26 @@ export default function useWaitHasEnergy() {
 
   const hasEnergyResolvers = useRef<(() => void)[]>([])
 
-  const generateNewPromise = useCallback(
-    () =>
-      new Promise<void>((resolve) => {
-        hasEnergyResolvers.current.push(() => resolve())
-      }),
-    []
-  )
+  const generateNewPromise = useCallback(() => {
+    return new Promise<void>((resolve) => {
+      hasEnergyResolvers.current.push(() => resolve())
+    })
+  }, [])
   // save current and previous account's promises, so there are no dangling promises
   const [hasEnergyPromises, setHasEnergyPromises] = useState<Promise<void>[]>(
     () => [generateNewPromise()]
   )
 
   useEffect(() => {
-    setHasEnergyPromises((prev) => [...prev, generateNewPromise()])
+    const newPromise = generateNewPromise()
+    setHasEnergyPromises((prev) => [...prev, newPromise])
   }, [address, generateNewPromise])
 
   useEffect(() => {
     if (!energy || energy <= 0) return
     hasEnergyResolvers.current.forEach((resolve) => resolve())
     hasEnergyResolvers.current = []
-  }, [energy, generateNewPromise])
+  }, [energy, generateNewPromise, hasEnergyPromises])
 
   return () => hasEnergyPromises[hasEnergyPromises.length - 1]
 }


### PR DESCRIPTION
# Issue
How to replicate:
1. go to a chat room and send message
2. go back to home page
3. go to chat room again and send message => it will wait for balance forever.

or

1. go to home page and wait for the account to load
2. go to chat room => send message

# Issue Cause
when go back to chat room, with the energy data already there, the new promise generator haven't set the resolver to the resolver ref but the effect to resolve is already ran.
