### PR TITLE
Fix IFrame Jumps Around Issue

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -35,8 +35,9 @@ export default function App(props: AppProps<AppCommonProps>) {
         }
       `}</style>
       {/* Fix issue with iframe height not calculated correctly in iframe */}
-      {isInIframe && (
-        <style jsx global>{`
+      <style jsx global>
+        {isInIframe
+          ? `
           html,
           body {
             height: 100%;
@@ -46,8 +47,9 @@ export default function App(props: AppProps<AppCommonProps>) {
           body {
             overflow-y: scroll;
           }
-        `}</style>
-      )}
+        `
+          : ''}
+      </style>
       <AppContent {...props} />
     </ConfigProvider>
   )

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -33,11 +33,9 @@ export default function App(props: AppProps<AppCommonProps>) {
         html {
           --source-sans-pro: ${sourceSansPro.style.fontFamily};
         }
-      `}</style>
-      {/* Fix issue with iframe height not calculated correctly in iframe */}
-      <style jsx global>{`
         ${isInIframe
-          ? `
+          ? // Fix issue with iframe height not calculated correctly in iframe
+            `
           html,
           body {
             height: 100%;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -26,6 +26,7 @@ const sourceSansPro = Source_Sans_Pro({
 })
 
 export default function App(props: AppProps<AppCommonProps>) {
+  const isInIframe = useIsInIframe()
   return (
     <ConfigProvider>
       <style jsx global>{`
@@ -33,6 +34,20 @@ export default function App(props: AppProps<AppCommonProps>) {
           --source-sans-pro: ${sourceSansPro.style.fontFamily};
         }
       `}</style>
+      {/* Fix issue with iframe height not calculated correctly in iframe */}
+      {isInIframe && (
+        <style jsx global>{`
+          html,
+          body {
+            height: 100%;
+            overflow: auto;
+            -webkit-overflow-scrolling: touch;
+          }
+          body {
+            overflow-y: scroll;
+          }
+        `}</style>
+      )}
       <AppContent {...props} />
     </ConfigProvider>
   )

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -35,8 +35,8 @@ export default function App(props: AppProps<AppCommonProps>) {
         }
       `}</style>
       {/* Fix issue with iframe height not calculated correctly in iframe */}
-      <style jsx global>
-        {isInIframe
+      <style jsx global>{`
+        ${isInIframe
           ? `
           html,
           body {
@@ -49,7 +49,7 @@ export default function App(props: AppProps<AppCommonProps>) {
           }
         `
           : ''}
-      </style>
+      `}</style>
       <AppContent {...props} />
     </ConfigProvider>
   )

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -40,12 +40,6 @@
   --border-gray: 51 59 74;
 }
 
-html {
-  height: 100%;
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
 .grecaptcha-badge {
   visibility: hidden;
   display: none;
@@ -55,7 +49,9 @@ html {
   @apply scrollbar-thin scrollbar-track-background scrollbar-thumb-background-lightest scrollbar-track-rounded-full scrollbar-thumb-rounded-full dark:scrollbar-thumb-background-lighter;
 }
 html {
+  height: 100%;
   overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
 }
 
 @tailwind base;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -40,8 +40,7 @@
   --border-gray: 51 59 74;
 }
 
-html,
-body {
+html {
   height: 100%;
   overflow: auto;
   -webkit-overflow-scrolling: touch;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -40,6 +40,13 @@
   --border-gray: 51 59 74;
 }
 
+html,
+body {
+  height: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 .grecaptcha-badge {
   visibility: hidden;
   display: none;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -48,13 +48,14 @@
 * {
   @apply scrollbar-thin scrollbar-track-background scrollbar-thumb-background-lightest scrollbar-track-rounded-full scrollbar-thumb-rounded-full dark:scrollbar-thumb-background-lighter;
 }
-html {
-  height: 100%;
-}
+html,
 body {
   height: 100%;
-  overflow-y: scroll;
+  overflow: auto;
   -webkit-overflow-scrolling: touch;
+}
+body {
+  overflow-y: scroll;
 }
 
 @tailwind base;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -48,14 +48,8 @@
 * {
   @apply scrollbar-thin scrollbar-track-background scrollbar-thumb-background-lightest scrollbar-track-rounded-full scrollbar-thumb-rounded-full dark:scrollbar-thumb-background-lighter;
 }
-html,
-body {
-  height: 100%;
+html {
   overflow-y: scroll;
-  -webkit-overflow-scrolling: touch;
-}
-body {
-  overflow-y: auto;
 }
 
 @tailwind base;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -51,11 +51,11 @@
 html,
 body {
   height: 100%;
-  overflow: auto;
+  overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
 }
 body {
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 @tailwind base;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -50,6 +50,9 @@
 }
 html {
   height: 100%;
+}
+body {
+  height: 100%;
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
# Issue
In ios, the iframe can jump around because the height is not calculated correctly.

# Solution
Put styles to fix that only in iframe, because if these styles are put in main chat, the scroll restoration won't work