### PR TITLE
Add encoding to fix resource id integration

### DIFF
--- a/integration/index.ts
+++ b/integration/index.ts
@@ -117,7 +117,7 @@ const grill = {
           break
         case 'resource':
           resourceId = channelConfig.resource.toResourceId()
-          baseUrl += `/resource/${resourceId}`
+          baseUrl += `/resource/${encodeURIComponent(resourceId)}`
           resourceMetadata = channelConfig.metadata
           break
         default:

--- a/src/components/chats/ChatRoom/ChatForm.tsx
+++ b/src/components/chats/ChatRoom/ChatForm.tsx
@@ -158,6 +158,7 @@ export default function ChatForm({
             >
               <TextArea
                 onEnterToSubmitForm={submitForm}
+                disabled={!chatId}
                 ref={textAreaRef}
                 value={messageBody}
                 onChange={(e) => setMessageBody((e.target as any).value)}


### PR DESCRIPTION
# Issue
Resource id is not encoded from the grill-widget, which makes the url results in 404.