### PR TITLE
Add Show Metadata to About Hub Modal

### DIFF
--- a/src/components/chats/ChatItem/ChatItem.tsx
+++ b/src/components/chats/ChatItem/ChatItem.tsx
@@ -185,7 +185,7 @@ export default function ChatItem({
       <MetadataModal
         isOpen={openMetadata}
         closeModal={() => setOpenMetadata(false)}
-        post={message}
+        entity={message}
       />
     </div>
   )

--- a/src/components/modals/MetadataModal.tsx
+++ b/src/components/modals/MetadataModal.tsx
@@ -1,35 +1,35 @@
 import Modal, { ModalFunctionalityProps } from '@/components/modals/Modal'
 import { getIpfsContentUrl, getSubIdUrl } from '@/utils/ipfs'
-import { PostData } from '@subsocial/api/types'
+import { PostData, SpaceData } from '@subsocial/api/types'
 import DataCard, { DataCardProps } from '../DataCard'
 
 export type MetadataModalProps = ModalFunctionalityProps & {
-  post: PostData
+  entity: PostData | SpaceData
   postIdTextPrefix?: string
 }
 
 export default function MetadataModal({
-  post,
+  entity,
   postIdTextPrefix = 'Post',
   ...props
 }: MetadataModalProps) {
   const metadataList: DataCardProps['data'] = [
     {
       title: `${postIdTextPrefix} ID:`,
-      content: post.id,
+      content: entity.id,
       withCopyButton: true,
     },
     {
       title: 'Content ID:',
-      content: post.struct.contentId ?? '',
-      redirectTo: getIpfsContentUrl(post.struct.contentId ?? ''),
+      content: entity.struct.contentId ?? '',
+      redirectTo: getIpfsContentUrl(entity.struct.contentId ?? ''),
       openInNewTab: true,
       withCopyButton: true,
     },
     {
       title: 'Owner:',
-      content: post.struct.ownerId ?? '',
-      redirectTo: getSubIdUrl(post.struct.ownerId ?? ''),
+      content: entity.struct.ownerId ?? '',
+      redirectTo: getSubIdUrl(entity.struct.ownerId ?? ''),
       openInNewTab: true,
       withCopyButton: true,
     },

--- a/src/components/modals/about/AboutChatModal.tsx
+++ b/src/components/modals/about/AboutChatModal.tsx
@@ -59,7 +59,7 @@ export default function AboutChatModal({
       <MetadataModal
         closeModal={() => setIsOpenMetadataModal(false)}
         isOpen={isOpenMetadataModal}
-        post={chat}
+        entity={chat}
         postIdTextPrefix='Chat'
       />
     </>

--- a/src/components/modals/about/AboutHubModal.tsx
+++ b/src/components/modals/about/AboutHubModal.tsx
@@ -1,7 +1,10 @@
 import { getSpaceBySpaceIdQuery } from '@/services/subsocial/spaces'
 import { getCurrentUrlOrigin, getHomePageLink } from '@/utils/links'
 import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { HiCircleStack } from 'react-icons/hi2'
 import urlJoin from 'url-join'
+import MetadataModal from '../MetadataModal'
 import { ModalFunctionalityProps } from '../Modal'
 import AboutModal, { AboutModalProps } from './AboutModal'
 
@@ -17,6 +20,7 @@ export default function AboutHubModal({
 }: AboutHubModalProps) {
   const router = useRouter()
   const { data: hub } = getSpaceBySpaceIdQuery.useQuery(hubId)
+  const [isOpenMetadataModal, setIsOpenMetadataModal] = useState(false)
 
   const content = hub?.content
   if (!content) return null
@@ -33,14 +37,31 @@ export default function AboutHubModal({
     },
   ]
 
+  const actionMenu: AboutModalProps['actionMenu'] = [
+    {
+      text: 'Show Metadata',
+      icon: HiCircleStack,
+      onClick: () => setIsOpenMetadataModal(true),
+    },
+  ]
+
   return (
-    <AboutModal
-      {...props}
-      title={content.name}
-      isImageCircle={false}
-      subtitle={`${chatCount} chats in hub`}
-      imageCid={content.image}
-      contentList={contentList}
-    />
+    <>
+      <AboutModal
+        {...props}
+        title={content.name}
+        isImageCircle={false}
+        subtitle={`${chatCount} chats in hub`}
+        imageCid={content.image}
+        contentList={contentList}
+        actionMenu={actionMenu}
+      />
+      <MetadataModal
+        closeModal={() => setIsOpenMetadataModal(false)}
+        isOpen={isOpenMetadataModal}
+        entity={hub}
+        postIdTextPrefix='Hub'
+      />
+    </>
   )
 }

--- a/src/components/modals/about/AboutHubModal.tsx
+++ b/src/components/modals/about/AboutHubModal.tsx
@@ -21,11 +21,7 @@ export default function AboutHubModal({
   const content = hub?.content
   if (!content) return null
 
-  const hubUrl = urlJoin(
-    getCurrentUrlOrigin(),
-    getHomePageLink(router),
-    '/about'
-  )
+  const hubUrl = urlJoin(getCurrentUrlOrigin(), getHomePageLink(router))
   const contentList: AboutModalProps['contentList'] = [
     { title: 'Description', content: content.about },
     {


### PR DESCRIPTION
# Other Change
- Remove /about in about hub modal's `hub link`

![image](https://github.com/dappforce/grillchat/assets/53143942/c5e87b1e-6fc8-494f-97e1-43fc34081cc5)
