### PR TITLE
Add try catch when prefetching from moderation

### DIFF
--- a/src/utils/server.ts
+++ b/src/utils/server.ts
@@ -7,17 +7,21 @@ import { SubsocialIpfsApi } from '@subsocial/api'
 import { QueryClient } from '@tanstack/react-query'
 import { getCrustIpfsAuth, getIpfsPinUrl } from './env/server'
 
-export function prefetchBlockedEntities(
+export async function prefetchBlockedEntities(
   queryClient: QueryClient,
   chatIds: string[]
 ) {
-  return Promise.all([
-    getBlockedCidsQuery.fetchQuery(queryClient, null),
-    getBlockedAddressesQuery.fetchQuery(queryClient, null),
-    ...chatIds.map((id) =>
-      getBlockedMessageIdsInChatIdQuery.fetchQuery(queryClient, id)
-    ),
-  ])
+  try {
+    return await Promise.all([
+      getBlockedCidsQuery.fetchQuery(queryClient, null),
+      getBlockedAddressesQuery.fetchQuery(queryClient, null),
+      ...chatIds.map((chatId) =>
+        getBlockedMessageIdsInChatIdQuery.fetchQuery(queryClient, chatId)
+      ),
+    ])
+  } catch (err) {
+    console.log('Error prefetching blocked entities', err)
+  }
 }
 
 export function getIpfsApi() {


### PR DESCRIPTION
# Issue
Currently, when the moderation server is down, all the prefetching things done in the homepage/chatpage will error out, making the page not generated at all.

# Solution
Add try catch to moderation fetching, so if the moderation errors out, it will only logs the error, but won't make the page generation errors