### PR TITLE
Allow image to be from outside of ipfs cid

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -45,6 +45,10 @@ const nextConfig = {
         port: '',
         pathname: '/ipfs/**',
       },
+      {
+        protocol: 'https',
+        hostname: '**',
+      },
     ],
   },
 }

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -1,4 +1,5 @@
 export function getIpfsContentUrl(cid: string) {
+  if (!cid || cid.startsWith('http')) return cid
   return `https://ipfs.subsocial.network/ipfs/${cid}`
 }
 


### PR DESCRIPTION
# Issue
With previous implementation, the image for resource metadata must be uploaded to ipfs before the cid can be used as the resource image. If you use any other url as the image, it can't be rendered in grill.

Now, it's changed so the image url can be from any source/link, and it can also be rendered in grill.