### PR TITLE
Fix open modal staggering in home page

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -29,9 +29,10 @@ const sourceSansPro = Source_Sans_Pro({
 export default function App(props: AppProps<AppCommonProps>) {
   const isInIframe = useIsInIframe()
 
+  const scrollbarSelector = isInIframe ? 'body' : 'html'
   const scrollbarStyling = props.pageProps.alwaysShowScrollbarOffset
     ? `
-      body {
+      ${scrollbarSelector} {
         overflow-y: scroll;
       }
     `


### PR DESCRIPTION
# Issue
because the `overflow-y: scroll` is put in the body, not html, the modal wrongly adds the padding right to the html to offset the scrollbar, while the scrollbar is still there in the body
This makes the modal moves a little bit when its appearing

![image](https://github.com/dappforce/grillchat/assets/53143942/ae221e4c-3abb-424d-8411-23c444dc4548)
Double scrollbar offset in the image above