### PR TITLE
Always show scrollbar in hubs page

### DIFF
--- a/src/components/modals/about/AboutChatModal.tsx
+++ b/src/components/modals/about/AboutChatModal.tsx
@@ -1,3 +1,4 @@
+import useIsInIframe from '@/hooks/useIsInIframe'
 import useIsJoinedToChat from '@/hooks/useIsJoinedToChat'
 import { getPostQuery } from '@/services/api/query'
 import {
@@ -32,6 +33,7 @@ export default function AboutChatModal({
   const [isOpenMetadataModal, setIsOpenMetadataModal] = useState(false)
   const [isOpenConfirmation, setIsOpenConfirmation] = useState(false)
 
+  const isInIframe = useIsInIframe()
   const { isJoined, isLoading } = useIsJoinedToChat(chatId)
 
   const content = chat?.content
@@ -62,7 +64,7 @@ export default function AboutChatModal({
       },
     ]
 
-    if (isLoading) return actionMenu
+    if (isLoading || isInIframe) return actionMenu
 
     if (isJoined) {
       actionMenu.push({

--- a/src/hooks/useIsJoinedToChat.ts
+++ b/src/hooks/useIsJoinedToChat.ts
@@ -1,8 +1,16 @@
 import { getFollowedPostIdsByAddressQuery } from '@/services/subsocial/posts'
 import { useMyAccount } from '@/stores/my-account'
 import { useMemo } from 'react'
+import useIsInIframe from './useIsInIframe'
+
+const isJoinedValue = {
+  isJoined: true,
+  isLoading: false,
+}
 
 export default function useIsJoinedToChat(chatId: string, address?: string) {
+  const isInIframe = useIsInIframe()
+
   const isInitialized = useMyAccount((state) => state.isInitialized)
   const myAddress = useMyAccount((state) => state.address)
   const usedAddress = address || myAddress
@@ -17,6 +25,10 @@ export default function useIsJoinedToChat(chatId: string, address?: string) {
     data?.forEach((id) => set.add(id))
     return set
   }, [data])
+
+  if (isInIframe) {
+    return isJoinedValue
+  }
 
   return { isJoined: followedPostIdsSet.has(chatId), isLoading }
 }

--- a/src/pages/hubs.tsx
+++ b/src/pages/hubs.tsx
@@ -12,7 +12,7 @@ import { dehydrate, QueryClient } from '@tanstack/react-query'
 export const getStaticProps = getCommonStaticProps<
   HubsPageProps & AppCommonProps
 >(
-  () => ({}),
+  () => ({ alwaysShowScrollbarOffset: true }),
   async () => {
     const hubsChatCount: HubsPageProps['hubsChatCount'] = {}
     const hubIds = getSpaceIds()


### PR DESCRIPTION
If not showing scrollbar all the time in hubs page, if user changes tab from `my chats` to `hot chats`, it will have some offset because of the scrollbar appear and disappearing