### PR TITLE
Remove join button for iframe integration

### DIFF
--- a/src/components/modals/about/AboutChatModal.tsx
+++ b/src/components/modals/about/AboutChatModal.tsx
@@ -1,3 +1,4 @@
+import useIsInIframe from '@/hooks/useIsInIframe'
 import useIsJoinedToChat from '@/hooks/useIsJoinedToChat'
 import { getPostQuery } from '@/services/api/query'
 import {
@@ -32,6 +33,7 @@ export default function AboutChatModal({
   const [isOpenMetadataModal, setIsOpenMetadataModal] = useState(false)
   const [isOpenConfirmation, setIsOpenConfirmation] = useState(false)
 
+  const isInIframe = useIsInIframe()
   const { isJoined, isLoading } = useIsJoinedToChat(chatId)
 
   const content = chat?.content
@@ -62,7 +64,7 @@ export default function AboutChatModal({
       },
     ]
 
-    if (isLoading) return actionMenu
+    if (isLoading || isInIframe) return actionMenu
 
     if (isJoined) {
       actionMenu.push({

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -60,7 +60,6 @@ const schemaGetter = {
     const enableBackButton = getUrlQuery('enableBackButton')
     const enableLoginButton = getUrlQuery('enableLoginButton')
     const enableInputAutofocus = getUrlQuery('enableInputAutofocus')
-    const enableJoinButton = getUrlQuery('enableJoinButton')
 
     const subscribeMessageCountThreshold = getUrlQuery(
       'subscribeMessageCountThreshold'
@@ -83,11 +82,6 @@ const schemaGetter = {
       ),
       enableInputAutofocus: validateStringConfig(
         enableInputAutofocus,
-        ['true', 'false'],
-        (value) => value === 'true'
-      ),
-      enableJoinButton: validateStringConfig(
-        enableJoinButton,
         ['true', 'false'],
         (value) => value === 'true'
       ),

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -8,7 +8,6 @@ type State = {
   enableBackButton?: boolean
   enableLoginButton?: boolean
   enableInputAutofocus?: boolean
-  enableJoinButton?: boolean
   subscribeMessageCountThreshold?: number
 }
 const ConfigContext = createContext<State>({ theme: undefined, order: [] })

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -8,6 +8,7 @@ type State = {
   enableBackButton?: boolean
   enableLoginButton?: boolean
   enableInputAutofocus?: boolean
+  enableJoinButton?: boolean
   subscribeMessageCountThreshold?: number
 }
 const ConfigContext = createContext<State>({ theme: undefined, order: [] })
@@ -59,6 +60,7 @@ const schemaGetter = {
     const enableBackButton = getUrlQuery('enableBackButton')
     const enableLoginButton = getUrlQuery('enableLoginButton')
     const enableInputAutofocus = getUrlQuery('enableInputAutofocus')
+    const enableJoinButton = getUrlQuery('enableJoinButton')
 
     const subscribeMessageCountThreshold = getUrlQuery(
       'subscribeMessageCountThreshold'
@@ -81,6 +83,11 @@ const schemaGetter = {
       ),
       enableInputAutofocus: validateStringConfig(
         enableInputAutofocus,
+        ['true', 'false'],
+        (value) => value === 'true'
+      ),
+      enableJoinButton: validateStringConfig(
+        enableJoinButton,
         ['true', 'false'],
         (value) => value === 'true'
       ),

--- a/src/hooks/useIsJoinedToChat.ts
+++ b/src/hooks/useIsJoinedToChat.ts
@@ -2,6 +2,7 @@ import { useConfigContext } from '@/contexts/ConfigContext'
 import { getFollowedPostIdsByAddressQuery } from '@/services/subsocial/posts'
 import { useMyAccount } from '@/stores/my-account'
 import { useMemo } from 'react'
+import useIsInIframe from './useIsInIframe'
 
 const isJoinedValue = {
   isJoined: true,
@@ -10,6 +11,8 @@ const isJoinedValue = {
 
 export default function useIsJoinedToChat(chatId: string, address?: string) {
   const { enableJoinButton } = useConfigContext()
+  const isInIframe = useIsInIframe()
+
   const isInitialized = useMyAccount((state) => state.isInitialized)
   const myAddress = useMyAccount((state) => state.address)
   const usedAddress = address || myAddress
@@ -25,7 +28,7 @@ export default function useIsJoinedToChat(chatId: string, address?: string) {
     return set
   }, [data])
 
-  if (enableJoinButton) {
+  if (isInIframe && !enableJoinButton) {
     return isJoinedValue
   }
 

--- a/src/hooks/useIsJoinedToChat.ts
+++ b/src/hooks/useIsJoinedToChat.ts
@@ -1,8 +1,15 @@
+import { useConfigContext } from '@/contexts/ConfigContext'
 import { getFollowedPostIdsByAddressQuery } from '@/services/subsocial/posts'
 import { useMyAccount } from '@/stores/my-account'
 import { useMemo } from 'react'
 
+const isJoinedValue = {
+  isJoined: true,
+  isLoading: false,
+}
+
 export default function useIsJoinedToChat(chatId: string, address?: string) {
+  const { enableJoinButton } = useConfigContext()
   const isInitialized = useMyAccount((state) => state.isInitialized)
   const myAddress = useMyAccount((state) => state.address)
   const usedAddress = address || myAddress
@@ -17,6 +24,10 @@ export default function useIsJoinedToChat(chatId: string, address?: string) {
     data?.forEach((id) => set.add(id))
     return set
   }, [data])
+
+  if (enableJoinButton) {
+    return isJoinedValue
+  }
 
   return { isJoined: followedPostIdsSet.has(chatId), isLoading }
 }

--- a/src/hooks/useIsJoinedToChat.ts
+++ b/src/hooks/useIsJoinedToChat.ts
@@ -1,4 +1,3 @@
-import { useConfigContext } from '@/contexts/ConfigContext'
 import { getFollowedPostIdsByAddressQuery } from '@/services/subsocial/posts'
 import { useMyAccount } from '@/stores/my-account'
 import { useMemo } from 'react'
@@ -10,7 +9,6 @@ const isJoinedValue = {
 }
 
 export default function useIsJoinedToChat(chatId: string, address?: string) {
-  const { enableJoinButton } = useConfigContext()
   const isInIframe = useIsInIframe()
 
   const isInitialized = useMyAccount((state) => state.isInitialized)
@@ -28,7 +26,7 @@ export default function useIsJoinedToChat(chatId: string, address?: string) {
     return set
   }, [data])
 
-  if (isInIframe && !enableJoinButton) {
+  if (isInIframe) {
     return isJoinedValue
   }
 


### PR DESCRIPTION
In iframe integration, they can't access hubs page, so it doesn't make sense to have join button there.