### PR TITLE
Fix issue with my chats last message loading indefinitely

### DIFF
--- a/src/components/chats/ChatPreviewList.tsx
+++ b/src/components/chats/ChatPreviewList.tsx
@@ -49,7 +49,7 @@ function ChatPreviewContainer({
   const content = chat?.content
 
   const hubId = chat.struct.spaceId
-  const aliasOrHub = getAliasFromSpaceId(hubId ?? '') ?? hubId
+  const aliasOrHub = getAliasFromSpaceId(hubId ?? '') || hubId
   const linkTo = getChatPageLink(
     router,
     createSlug(chat.id, { title: content?.title }),

--- a/src/modules/chat/HubsPage/MyChatsContent.tsx
+++ b/src/modules/chat/HubsPage/MyChatsContent.tsx
@@ -55,7 +55,7 @@ function Loading() {
   return (
     <div className='flex flex-col'>
       {Array.from({ length: 3 }).map((_, idx) => (
-        <ChatPreviewSkeleton key={idx} />
+        <ChatPreviewSkeleton asContainer key={idx} />
       ))}
     </div>
   )

--- a/src/services/subsocial/commentIds/subscription.ts
+++ b/src/services/subsocial/commentIds/subscription.ts
@@ -15,8 +15,7 @@ const subscription = (
   lastIdInPreviousSub: {
     get: () => string | undefined
     set: (id: string | undefined) => void
-  },
-  callback?: (ids: string[]) => void
+  }
 ) => {
   if (!enabled || subscribedPostIds.has(postId)) return
   subscribedPostIds.add(postId)
@@ -46,10 +45,8 @@ const subscription = (
         )
       }
 
-      // first subscription, set data immediately
       if (lastSubscribedId === undefined) {
         updateQueryData()
-        callback?.(newIds)
         return
       }
 
@@ -85,32 +82,24 @@ const subscription = (
 
 export function useSubscribeCommentIdsByPostId(
   postId: string,
-  enabled: boolean,
-  callbackFirstResult?: (ids: string[]) => void
+  enabled: boolean
 ) {
   const queryClient = useQueryClient()
 
   const lastIdInPreviousSub = useRef<string>()
-  const callbackRef = useWrapInRef(callbackFirstResult)
 
   useEffect(() => {
-    const unsub = subscription(
-      enabled,
-      postId,
-      queryClient,
-      {
-        get: () => lastIdInPreviousSub.current,
-        set: (id) => (lastIdInPreviousSub.current = id),
-      },
-      callbackRef.current
-    )
+    const unsub = subscription(enabled, postId, queryClient, {
+      get: () => lastIdInPreviousSub.current,
+      set: (id) => (lastIdInPreviousSub.current = id),
+    })
 
     return () => {
       unsub?.then((func) => func())
       lastIdInPreviousSub.current = undefined
       if (unsub) subscribedPostIds.delete(postId)
     }
-  }, [postId, queryClient, enabled, callbackRef])
+  }, [postId, queryClient, enabled])
 }
 
 export function useSubscribeCommentIdsByPostIds(
@@ -124,35 +113,20 @@ export function useSubscribeCommentIdsByPostIds(
   const callbackRef = useWrapInRef(callbackFirstResult)
 
   useEffect(() => {
-    const resolvers: ((value: string[] | PromiseLike<string[]>) => void)[] = []
-    const promises = postIds.map((postId) => {
-      return new Promise<string[]>((resolve) => {
-        resolvers.push(resolve)
+    const unsubs = postIds.map((postId) => {
+      return subscription(enabled, postId, queryClient, {
+        get: () => lastIdInPreviousSub.current[postId],
+        set: (id) => (lastIdInPreviousSub.current[postId] = id),
       })
-    })
-
-    const unsubs = postIds.map((postId, idx) => {
-      return subscription(
-        enabled,
-        postId,
-        queryClient,
-        {
-          get: () => lastIdInPreviousSub.current[postId],
-          set: (id) => (lastIdInPreviousSub.current[postId] = id),
-        },
-        resolvers[idx]
-      )
-    })
-
-    Promise.all(promises).then((ids) => {
-      callbackRef.current?.(ids)
     })
 
     return () => {
       lastIdInPreviousSub.current = {}
       unsubs.forEach((unsub, idx) => {
         unsub?.then((func) => func())
-        if (unsub) subscribedPostIds.delete(postIds[idx])
+        if (unsub) {
+          subscribedPostIds.delete(postIds[idx])
+        }
       })
     }
   }, [postIds, queryClient, enabled, callbackRef])


### PR DESCRIPTION
# Issue Explanation
The issue is when you joined chats other than the main hub (/x), and access "my chats" tab, because it fetches the data from client.

This issue was caused by `poolQuery` implementation.
The issue is triggerred when:
1. fetch post id 1, 2, 3
2. no more request for 200ms, so the fetch starts
3. fetch post 4, 5, 6
4. number 2 part is not done yet (still fetching), and because the reset is done in the end, the pooled queries are still not reset, so it now starts fetching post 1, 2, 3, 4, 5, 6
5. number 3 part is resolved, and it resolves all the promises for post 1, 2, 3, 4, 5, 6, but 4, 5, 6 is resolved with undefined.
6. when number 4 is done, the data is not saved anywhere => this is what makes the issue

## Solution
When the fetcher function is called, it immediately resets the queries data and the resolvers so the fetched data resolves only the related ids.

# Simplifying Subscription Code
Previously, I made a pretty complex promise based things for resolving the query, because I don't know that setting the query data manually from the `queryClient` can remove the loading state for that data.
Because of that, I made the worker function to wait for first subscription result which then be returned and set as the data. Turns out its not needed

So the current flow is:
1. Any component calls the useQuery, in this case `useCommentIdByPostId`
8. The hook runs the worker function, and starts subscribing to blockchain
9. The worker function will just wait indefinitely => this is to make the query thinks its still in loading state (so the isLoading returned from that `useCommentIdByPostId` will be true.
10. The subscription method gets the data, and set it manually using queryClient. This will make the isLoading state for that query gone, and the data is now set.

# Other Changes
- Fix issue with link for my chats consisting of chats in hub without alias is not correct. 
  For example, if you add bitcoin in 1001 hub, `/1001/bitcoin-1` to your chat, the link from that chat preview will be `/bitcoin-1` 
- Add padding to left and right of chat skeleton (so it not touches the edge of screen in mobile)