### PR TITLE
Fix back button issue

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -12,7 +12,7 @@ export type BackButtonProps = ButtonProps & {
 
 export default function BackButton({
   defaultBackLink = '/',
-  forceUseDefaultBackLink,
+  forceUseDefaultBackLink = true,
   noStyle,
   ...props
 }: BackButtonProps) {

--- a/src/modules/chat/ChatPage/ChatPage.tsx
+++ b/src/modules/chat/ChatPage/ChatPage.tsx
@@ -63,9 +63,7 @@ export default function ChatPage({
     <DefaultLayout
       withFixedHeight
       navbarProps={{
-        backButtonProps: {
-          defaultBackLink: getHomePageLink(router),
-        },
+        backButtonProps: { defaultBackLink: getHomePageLink(router) },
         customContent: ({ backButton, authComponent, colorModeToggler }) => (
           <div className='flex items-center justify-between gap-4'>
             <NavbarChatInfo

--- a/src/modules/chat/HomePage/HomePage.tsx
+++ b/src/modules/chat/HomePage/HomePage.tsx
@@ -29,10 +29,7 @@ export default function HomePage({ hubId }: HomePageProps) {
   return (
     <DefaultLayout
       navbarProps={{
-        backButtonProps: {
-          defaultBackLink: '/hubs',
-          forceUseDefaultBackLink: true,
-        },
+        backButtonProps: { defaultBackLink: '/hubs' },
         customContent: ({
           backButton,
           logoLink,


### PR DESCRIPTION
# Issue
When you access message page (e.g. https://grill.chat/x/polkadot-754/4700), the prevUrl will be detected as `/x/polkadot-754/4700`, where based on the current logic, it will use `router.back` function, so it won't be redirecting you anywhere (because there is no history yet for that tab)

# Solution
Make `forceUseDefaultBackLink` props default to `true`, so all back button will be using the back link provided. Only if the previous url is the same as the back link, it will use router.back to make the scroll restoration works nicely.