### PR TITLE
Fix back issue

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -10,6 +10,8 @@ export type BackButtonProps = ButtonProps & {
   noStyle?: boolean
 }
 
+const homeLinks = ['/', '/my-chats', '/hubs', '/hot-chats']
+
 export default function BackButton({
   defaultBackLink = '/',
   forceUseDefaultBackLink = true,
@@ -23,7 +25,10 @@ export default function BackButton({
   const hasBackToCurrentSession = !!prevUrl
 
   const prevUrlPathname = prevUrl?.replace(getCurrentUrlOrigin(), '')
-  const isDefaultBackLinkSameAsPrevUrl = defaultBackLink === prevUrlPathname
+  let isDefaultBackLinkSameAsPrevUrl = defaultBackLink === prevUrlPathname
+  if (homeLinks.includes(defaultBackLink)) {
+    isDefaultBackLinkSameAsPrevUrl = homeLinks.includes(prevUrlPathname ?? '')
+  }
 
   const shouldUseRouterBack =
     hasBackToCurrentSession &&

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -38,7 +38,7 @@ export const getStaticProps = getCommonStaticProps<
         getSpaceBySpaceIdQuery.setQueryData(queryClient, hub.id, hub)
       })
     } catch (err) {
-      console.error('Error fetching for hubs page: ', err)
+      console.error('Error fetching for home page: ', err)
     }
 
     return {


### PR DESCRIPTION
# Issue
When from /hubs, and go to a hub, and press back button, it will go back to either hot-chats or my-chats (based on whether you have saved posts)

# Solution
Add additional checker for home page, which has 4 urls (`/`, `/my-chats`, `/hubs`, `/hot-chats`)