### PR TITLE
Use Global Channel Search for Home Page

### DIFF
--- a/src/components/chats/ChatPreviewSkeleton.tsx
+++ b/src/components/chats/ChatPreviewSkeleton.tsx
@@ -8,7 +8,7 @@ export type ChatPreviewSkeletonProps = ComponentProps<'div'> & {
   withBorderBottom?: boolean
 }
 
-export default function ChatPreviewSkeleton({
+function ChatPreviewSkeleton({
   asContainer,
   isImageCircle = true,
   withBorderBottom = true,
@@ -52,3 +52,19 @@ export default function ChatPreviewSkeleton({
     </Component>
   )
 }
+
+function ChatPreviewSkeletonList({
+  amount = 3,
+  ...props
+}: ComponentProps<'div'> & { amount?: number }) {
+  return (
+    <div {...props} className={cx('flex flex-col', props.className)}>
+      {Array.from({ length: amount }).map((_, idx) => (
+        <ChatPreviewSkeleton asContainer key={idx} />
+      ))}
+    </div>
+  )
+}
+
+ChatPreviewSkeleton.SkeletonList = ChatPreviewSkeletonList
+export default ChatPreviewSkeleton

--- a/src/components/chats/NoChatsFound.tsx
+++ b/src/components/chats/NoChatsFound.tsx
@@ -23,11 +23,11 @@ export default function NoChatsFound({ search, hubId }: NoChatsFoundProps) {
   return (
     <Container
       as='div'
-      className='mt-20 flex !max-w-lg flex-col items-center justify-center gap-4 text-center'
+      className='mb-8 mt-12 flex !max-w-lg flex-col items-center justify-center gap-4 text-center md:mt-20'
     >
       <Image
         src={NoResultImage}
-        className='h-64 w-64'
+        className='h-48 w-48'
         alt=''
         role='presentation'
       />

--- a/src/components/chats/NoChatsFound.tsx
+++ b/src/components/chats/NoChatsFound.tsx
@@ -1,8 +1,10 @@
 import NoResultImage from '@/assets/graphics/no-result.png'
 import Button from '@/components/Button'
 import Container from '@/components/Container'
+import { getHubIdFromAlias } from '@/constants/hubs'
 import { getSuggestNewChatRoomLink } from '@/constants/links'
 import Image from 'next/image'
+import { useRouter } from 'next/router'
 import { HiArrowUpRight } from 'react-icons/hi2'
 
 export type NoChatsFoundProps = {
@@ -11,6 +13,13 @@ export type NoChatsFoundProps = {
 }
 
 export default function NoChatsFound({ search, hubId }: NoChatsFoundProps) {
+  const router = useRouter()
+
+  let paramHubId = router.query.hubId as string
+  paramHubId = getHubIdFromAlias(paramHubId) || paramHubId
+
+  const usedHubId = hubId || paramHubId
+
   return (
     <Container
       as='div'
@@ -31,7 +40,7 @@ export default function NoChatsFound({ search, hubId }: NoChatsFoundProps) {
       <Button
         className='mt-4 w-full'
         size='lg'
-        href={getSuggestNewChatRoomLink({ chatName: search, hubId })}
+        href={getSuggestNewChatRoomLink({ chatName: search, hubId: usedHubId })}
         target='_blank'
         rel='noopener noreferrer'
       >

--- a/src/components/navbar/Navbar/custom/NavbarWithSearch.tsx
+++ b/src/components/navbar/Navbar/custom/NavbarWithSearch.tsx
@@ -81,7 +81,7 @@ export default function NavbarWithSearch({
     <div className='relative'>
       <div
         className={cx(
-          'absolute top-1/2 left-0 z-10 w-full -translate-y-1/2 transition-opacity',
+          'absolute left-0 top-1/2 z-10 w-full -translate-y-1/2 transition-opacity',
           !isOpenSearch && 'pointer-events-none opacity-0'
         )}
       >

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+
+function useDebounce<T>(value: T, delay?: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay || 500)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}
+
+export default useDebounce

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,28 +1,13 @@
-import { removeDoubleSpaces } from '@/utils/strings'
-import { matchSorter } from 'match-sorter'
 import { useEffect, useState } from 'react'
 
 export default function useSearch() {
   const [search, setSearch] = useState('')
   const [focusedElementIndex, setFocusedElementIndex] = useState(-1)
 
-  const getSearchResults = <T>(data: T[], searchKeys: string[]) => {
-    let searchResults = data
-    const processedSearch = removeDoubleSpaces(search)
-
-    if (processedSearch) {
-      searchResults = matchSorter(data, processedSearch, {
-        keys: searchKeys,
-      })
-    }
-
-    return {
-      searchResults,
-      focusedElementIndex:
-        focusedElementIndex === -1
-          ? focusedElementIndex
-          : focusedElementIndex % searchResults.length,
-    }
+  const getFocusedElementIndex = (searchResults: unknown[]) => {
+    return focusedElementIndex === -1
+      ? focusedElementIndex
+      : focusedElementIndex % searchResults.length
   }
 
   const removeFocusedElement = () => {
@@ -42,7 +27,7 @@ export default function useSearch() {
   return {
     search,
     setSearch,
-    getSearchResults,
+    getFocusedElementIndex,
     focusController: {
       removeFocusedElement,
       onDownClick,

--- a/src/modules/chat/HomePage/HomePage.tsx
+++ b/src/modules/chat/HomePage/HomePage.tsx
@@ -8,7 +8,7 @@ import { getMainHubId } from '@/utils/env/client'
 import { replaceUrl } from '@/utils/window'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
-import SearchContentWrapper from '../SearchContentWrapper'
+import SearchChannelsWrapper from '../SearchChannelsWrapper'
 import HotChatsContent from './HotChatsContent'
 import HubsContent from './HubsContent'
 import MyChatsContent from './MyChatsContent'
@@ -26,19 +26,14 @@ export default function HubsPage(props: HubsPageProps) {
   const { search, setSearch, getFocusedElementIndex, focusController } =
     useSearch()
 
-  const renderHubsContent = (
-    children: JSX.Element,
-    showSpecialButtons?: boolean
-  ) => {
+  const renderHubsContent = (children: JSX.Element) => {
     return (
-      <SearchContentWrapper
+      <SearchChannelsWrapper
         search={search}
-        isIntegrateChatButtonOnTop={props.isIntegrateChatButtonOnTop}
-        showSpecialButtons={showSpecialButtons}
         getFocusedElementIndex={getFocusedElementIndex}
       >
         {children}
-      </SearchContentWrapper>
+      </SearchChannelsWrapper>
     )
   }
 
@@ -62,8 +57,10 @@ export default function HubsPage(props: HubsPageProps) {
       text: 'Hubs',
       content: () =>
         renderHubsContent(
-          <HubsContent hubsChatCount={props.hubsChatCount} />,
-          true
+          <HubsContent
+            isIntegrateChatButtonOnTop={props.isIntegrateChatButtonOnTop}
+            hubsChatCount={props.hubsChatCount}
+          />
         ),
     },
   ]

--- a/src/modules/chat/HomePage/HomePage.tsx
+++ b/src/modules/chat/HomePage/HomePage.tsx
@@ -26,42 +26,28 @@ export default function HubsPage(props: HubsPageProps) {
   const { search, setSearch, getFocusedElementIndex, focusController } =
     useSearch()
 
-  const renderHubsContent = (children: JSX.Element) => {
-    return (
-      <SearchChannelsWrapper
-        search={search}
-        getFocusedElementIndex={getFocusedElementIndex}
-      >
-        {children}
-      </SearchChannelsWrapper>
-    )
-  }
-
   const tabs: TabsProps['tabs'] = [
     {
       id: 'my-chats',
       text: 'My Chats',
-      content: (setSelectedTab) =>
-        renderHubsContent(
-          <MyChatsContent changeTab={setSelectedTab} search={search} />
-        ),
+      content: (setSelectedTab) => (
+        <MyChatsContent changeTab={setSelectedTab} />
+      ),
     },
     {
       id: 'hot-chats',
       text: 'Hot Chats',
-      content: () =>
-        renderHubsContent(<HotChatsContent hubId={hotChatsHubId} />),
+      content: () => <HotChatsContent hubId={hotChatsHubId} />,
     },
     {
       id: 'hubs',
       text: 'Hubs',
-      content: () =>
-        renderHubsContent(
-          <HubsContent
-            isIntegrateChatButtonOnTop={props.isIntegrateChatButtonOnTop}
-            hubsChatCount={props.hubsChatCount}
-          />
-        ),
+      content: () => (
+        <HubsContent
+          isIntegrateChatButtonOnTop={props.isIntegrateChatButtonOnTop}
+          hubsChatCount={props.hubsChatCount}
+        />
+      ),
     },
   ]
 
@@ -127,17 +113,22 @@ export default function HubsPage(props: HubsPageProps) {
         },
       }}
     >
-      <Tabs
-        className='border-b border-border-gray bg-background-light px-1 md:bg-background-light/50'
-        panelClassName='mt-0 px-0'
-        asContainer
-        tabs={tabs}
-        withHashIntegration={false}
-        manualTabControl={{
-          selectedTab: usedSelectedTab,
-          setSelectedTab: usedSetSelectedTab,
-        }}
-      />
+      <SearchChannelsWrapper
+        search={search}
+        getFocusedElementIndex={getFocusedElementIndex}
+      >
+        <Tabs
+          className='border-b border-border-gray bg-background-light px-1 md:bg-background-light/50'
+          panelClassName='mt-0 px-0'
+          asContainer
+          tabs={tabs}
+          withHashIntegration={false}
+          manualTabControl={{
+            selectedTab: usedSelectedTab,
+            setSelectedTab: usedSetSelectedTab,
+          }}
+        />
+      </SearchChannelsWrapper>
     </DefaultLayout>
   )
 }

--- a/src/modules/chat/HomePage/HomePage.tsx
+++ b/src/modules/chat/HomePage/HomePage.tsx
@@ -1,8 +1,6 @@
-import ChatSpecialButtons from '@/components/chats/ChatSpecialButtons'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
 import NavbarWithSearch from '@/components/navbar/Navbar/custom/NavbarWithSearch'
 import Tabs, { TabsProps } from '@/components/Tabs'
-import useIsInIframe from '@/hooks/useIsInIframe'
 import useSearch from '@/hooks/useSearch'
 import { getFollowedPostIdsByAddressQuery } from '@/services/subsocial/posts'
 import { accountAddressStorage, useMyAccount } from '@/stores/my-account'
@@ -10,43 +8,37 @@ import { getMainHubId } from '@/utils/env/client'
 import { replaceUrl } from '@/utils/window'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
+import SearchContentWrapper from '../SearchContentWrapper'
 import HotChatsContent from './HotChatsContent'
 import HubsContent from './HubsContent'
 import MyChatsContent from './MyChatsContent'
-
-// const WelcomeModal = dynamic(() => import('@/components/modals/WelcomeModal'), {
-//   ssr: false,
-// })
 
 export type HubsPageProps = {
   isIntegrateChatButtonOnTop: boolean
   hubsChatCount: { [id: string]: number }
 }
 
-export type CommonHubContentProps = {
-  getSearchResults: ReturnType<typeof useSearch>['getSearchResults']
-}
-
 const hotChatsHubId = getMainHubId()
 const addressFromStorage = accountAddressStorage.get()
 
 export default function HubsPage(props: HubsPageProps) {
-  // const isInIframe = useIsInIframe()
   const router = useRouter()
-  const { search, setSearch, getSearchResults, focusController } = useSearch()
+  const { search, setSearch, getFocusedElementIndex, focusController } =
+    useSearch()
 
   const renderHubsContent = (
     children: JSX.Element,
     showSpecialButtons?: boolean
   ) => {
     return (
-      <HubsContentWrapper
+      <SearchContentWrapper
         search={search}
         isIntegrateChatButtonOnTop={props.isIntegrateChatButtonOnTop}
         showSpecialButtons={showSpecialButtons}
+        getFocusedElementIndex={getFocusedElementIndex}
       >
         {children}
-      </HubsContentWrapper>
+      </SearchContentWrapper>
     )
   }
 
@@ -56,33 +48,21 @@ export default function HubsPage(props: HubsPageProps) {
       text: 'My Chats',
       content: (setSelectedTab) =>
         renderHubsContent(
-          <MyChatsContent
-            changeTab={setSelectedTab}
-            search={search}
-            getSearchResults={getSearchResults}
-          />
+          <MyChatsContent changeTab={setSelectedTab} search={search} />
         ),
     },
     {
       id: 'hot-chats',
       text: 'Hot Chats',
       content: () =>
-        renderHubsContent(
-          <HotChatsContent
-            getSearchResults={getSearchResults}
-            hubId={hotChatsHubId}
-          />
-        ),
+        renderHubsContent(<HotChatsContent hubId={hotChatsHubId} />),
     },
     {
       id: 'hubs',
       text: 'Hubs',
       content: () =>
         renderHubsContent(
-          <HubsContent
-            getSearchResults={getSearchResults}
-            hubsChatCount={props.hubsChatCount}
-          />,
+          <HubsContent hubsChatCount={props.hubsChatCount} />,
           true
         ),
     },
@@ -161,31 +141,6 @@ export default function HubsPage(props: HubsPageProps) {
           setSelectedTab: usedSetSelectedTab,
         }}
       />
-      {/* {!isInIframe && <WelcomeModal />} */}
     </DefaultLayout>
-  )
-}
-
-function HubsContentWrapper({
-  isIntegrateChatButtonOnTop,
-  children,
-  search,
-  showSpecialButtons,
-}: {
-  isIntegrateChatButtonOnTop: boolean
-  children: JSX.Element
-  search: string
-  showSpecialButtons?: boolean
-}) {
-  const isInIframe = useIsInIframe()
-  return (
-    <div className='flex flex-col'>
-      {showSpecialButtons && !isInIframe && !search && (
-        <ChatSpecialButtons
-          isIntegrateChatButtonOnTop={isIntegrateChatButtonOnTop}
-        />
-      )}
-      {children}
-    </div>
   )
 }

--- a/src/modules/chat/HomePage/HotChatsContent.tsx
+++ b/src/modules/chat/HomePage/HotChatsContent.tsx
@@ -1,30 +1,12 @@
 import ChatPreviewList from '@/components/chats/ChatPreviewList'
-import NoChatsFound from '@/components/chats/NoChatsFound'
 import useSortedChats from '../hooks/useSortedChats'
-import { CommonHubContentProps } from './HomePage'
 
-export type HotChatsContentProps = CommonHubContentProps & {
+export type HotChatsContentProps = {
   hubId: string
 }
 
-export default function HotChatsContent({
-  getSearchResults,
-  hubId,
-}: HotChatsContentProps) {
+export default function HotChatsContent({ hubId }: HotChatsContentProps) {
   const { chats } = useSortedChats(hubId)
 
-  const { searchResults, focusedElementIndex } = getSearchResults(chats, [
-    'content.title',
-  ])
-
-  if (searchResults.length === 0) {
-    return <NoChatsFound search='' hubId={hubId} />
-  }
-
-  return (
-    <ChatPreviewList
-      chats={searchResults}
-      focusedElementIndex={focusedElementIndex}
-    />
-  )
+  return <ChatPreviewList chats={chats} />
 }

--- a/src/modules/chat/HomePage/HubsContent.tsx
+++ b/src/modules/chat/HomePage/HubsContent.tsx
@@ -1,4 +1,5 @@
 import ChatPreview from '@/components/chats/ChatPreview'
+import ChatSpecialButtons from '@/components/chats/ChatSpecialButtons'
 import { getAliasFromHubId } from '@/constants/hubs'
 import useIsInIframe from '@/hooks/useIsInIframe'
 import { getSpaceQuery } from '@/services/subsocial/spaces'
@@ -12,25 +13,35 @@ import { HubsPageProps } from './HomePage'
 
 export default function HubsContent({
   hubsChatCount = {},
-}: Pick<HubsPageProps, 'hubsChatCount'>) {
+  isIntegrateChatButtonOnTop,
+}: Pick<HubsPageProps, 'hubsChatCount' | 'isIntegrateChatButtonOnTop'>) {
+  const isInIframe = useIsInIframe()
   const hubIds = getHubIds()
 
   const hubQueries = getSpaceQuery.useQueries(hubIds)
   const hubs = hubQueries.map(({ data: hub }) => hub)
 
   return (
-    <div className='flex flex-col overflow-auto'>
-      {hubs.map((hub) => {
-        if (!hub) return null
-        const hubId = hub.id
-        return (
-          <ChatPreviewContainer
-            hub={hub}
-            chatCount={hubsChatCount[hubId]}
-            key={hubId}
-          />
-        )
-      })}
+    <div className='flex flex-col'>
+      {!isInIframe && (
+        <ChatSpecialButtons
+          isIntegrateChatButtonOnTop={!!isIntegrateChatButtonOnTop}
+        />
+      )}
+
+      <div className='flex flex-col overflow-auto'>
+        {hubs.map((hub) => {
+          if (!hub) return null
+          const hubId = hub.id
+          return (
+            <ChatPreviewContainer
+              hub={hub}
+              chatCount={hubsChatCount[hubId]}
+              key={hubId}
+            />
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/src/modules/chat/HomePage/HubsContent.tsx
+++ b/src/modules/chat/HomePage/HubsContent.tsx
@@ -8,28 +8,23 @@ import { getIpfsContentUrl } from '@/utils/ipfs'
 import { SpaceData } from '@subsocial/api/types'
 import { useRouter } from 'next/router'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { CommonHubContentProps, HubsPageProps } from './HomePage'
+import { HubsPageProps } from './HomePage'
 
 export default function HubsContent({
   hubsChatCount = {},
-  getSearchResults,
-}: CommonHubContentProps & Pick<HubsPageProps, 'hubsChatCount'>) {
+}: Pick<HubsPageProps, 'hubsChatCount'>) {
   const hubIds = getHubIds()
 
   const hubQueries = getSpaceQuery.useQueries(hubIds)
   const hubs = hubQueries.map(({ data: hub }) => hub)
-  const { searchResults, focusedElementIndex } = getSearchResults(hubs, [
-    'content.name',
-  ])
 
   return (
     <div className='flex flex-col overflow-auto'>
-      {searchResults.map((hub, idx) => {
+      {hubs.map((hub) => {
         if (!hub) return null
         const hubId = hub.id
         return (
           <ChatPreviewContainer
-            isFocused={idx === focusedElementIndex}
             hub={hub}
             chatCount={hubsChatCount[hubId]}
             key={hubId}

--- a/src/modules/chat/HomePage/MyChatsContent.tsx
+++ b/src/modules/chat/HomePage/MyChatsContent.tsx
@@ -2,22 +2,19 @@ import NoResultImage from '@/assets/graphics/no-result.png'
 import Button from '@/components/Button'
 import ChatPreviewList from '@/components/chats/ChatPreviewList'
 import ChatPreviewSkeleton from '@/components/chats/ChatPreviewSkeleton'
-import NoChatsFound from '@/components/chats/NoChatsFound'
 import Container from '@/components/Container'
 import { getPostQuery } from '@/services/api/query'
 import { getFollowedPostIdsByAddressQuery } from '@/services/subsocial/posts'
 import { useMyAccount } from '@/stores/my-account'
 import Image from 'next/image'
 import useSortChatIdsByLatestMessage from '../hooks/useSortChatIdsByLatestMessage'
-import { CommonHubContentProps } from './HomePage'
 
-export type MyChatsContentProps = CommonHubContentProps & {
+export type MyChatsContentProps = {
   search: string
   changeTab: (selectedTab: number) => void
 }
 
 export default function MyChatsContent({
-  getSearchResults,
   changeTab,
   search,
 }: MyChatsContentProps) {
@@ -35,33 +32,13 @@ export default function MyChatsContent({
   const chatQueries = getPostQuery.useQueries(sortedIds)
   const chats = chatQueries.map((query) => query.data)
 
-  const { searchResults, focusedElementIndex } = getSearchResults(chats, [
-    'content.title',
-  ])
-
   if (!isInitialized || isLoading || isPlaceholderData) {
-    return <Loading />
-  } else if (!address || searchResults.length === 0) {
-    if (search) return <NoChatsFound search={search} />
+    return <ChatPreviewSkeleton.SkeletonList />
+  } else if (!address || chats.length === 0) {
     return <NoChats changeTab={changeTab} />
   }
 
-  return (
-    <ChatPreviewList
-      chats={searchResults}
-      focusedElementIndex={focusedElementIndex}
-    />
-  )
-}
-
-function Loading() {
-  return (
-    <div className='flex flex-col'>
-      {Array.from({ length: 3 }).map((_, idx) => (
-        <ChatPreviewSkeleton asContainer key={idx} />
-      ))}
-    </div>
-  )
+  return <ChatPreviewList chats={chats} />
 }
 
 function NoChats({ changeTab }: Pick<MyChatsContentProps, 'changeTab'>) {

--- a/src/modules/chat/HomePage/MyChatsContent.tsx
+++ b/src/modules/chat/HomePage/MyChatsContent.tsx
@@ -10,14 +10,10 @@ import Image from 'next/image'
 import useSortChatIdsByLatestMessage from '../hooks/useSortChatIdsByLatestMessage'
 
 export type MyChatsContentProps = {
-  search: string
   changeTab: (selectedTab: number) => void
 }
 
-export default function MyChatsContent({
-  changeTab,
-  search,
-}: MyChatsContentProps) {
+export default function MyChatsContent({ changeTab }: MyChatsContentProps) {
   const isInitialized = useMyAccount((state) => state.isInitialized)
   const address = useMyAccount((state) => state.address)
 
@@ -45,11 +41,11 @@ function NoChats({ changeTab }: Pick<MyChatsContentProps, 'changeTab'>) {
   return (
     <Container
       as='div'
-      className='mt-20 flex !max-w-lg flex-col items-center justify-center gap-4 text-center'
+      className='mb-8 mt-12 flex !max-w-lg flex-col items-center justify-center gap-4 text-center md:mt-20'
     >
       <Image
         src={NoResultImage}
-        className='h-64 w-64'
+        className='h-48 w-48'
         alt=''
         role='presentation'
       />

--- a/src/modules/chat/HubPage/HubPage.tsx
+++ b/src/modules/chat/HubPage/HubPage.tsx
@@ -2,7 +2,7 @@ import ChatPreviewList from '@/components/chats/ChatPreviewList'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
 import useSearch from '@/hooks/useSearch'
 import useSortedChats from '../hooks/useSortedChats'
-import SearchContentWrapper from '../SearchContentWrapper'
+import SearchChannelsWrapper from '../SearchChannelsWrapper'
 import HubPageNavbar from './HubPageNavbar'
 
 export type HubPageProps = {
@@ -40,12 +40,12 @@ export default function HubPage({ hubId }: HubPageProps) {
         },
       }}
     >
-      <SearchContentWrapper
+      <SearchChannelsWrapper
         getFocusedElementIndex={getFocusedElementIndex}
         search={search}
       >
         <ChatPreviewList chats={chats} />
-      </SearchContentWrapper>
+      </SearchChannelsWrapper>
     </DefaultLayout>
   )
 }

--- a/src/modules/chat/HubPage/HubPage.tsx
+++ b/src/modules/chat/HubPage/HubPage.tsx
@@ -1,28 +1,17 @@
 import ChatPreviewList from '@/components/chats/ChatPreviewList'
-import NoChatsFound from '@/components/chats/NoChatsFound'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
 import useSearch from '@/hooks/useSearch'
 import useSortedChats from '../hooks/useSortedChats'
+import SearchContentWrapper from '../SearchContentWrapper'
 import HubPageNavbar from './HubPageNavbar'
-
-// const WelcomeModal = dynamic(() => import('@/components/modals/WelcomeModal'), {
-//   ssr: false,
-// })
 
 export type HubPageProps = {
   hubId: string
 }
-const searchKeys = ['content.title']
 export default function HubPage({ hubId }: HubPageProps) {
-  // const isInIframe = useIsInIframe()
-
   const { chats, allChatIds } = useSortedChats(hubId)
-
-  const { search, getSearchResults, setSearch, focusController } = useSearch()
-  const { focusedElementIndex, searchResults } = getSearchResults(
-    chats,
-    searchKeys
-  )
+  const { search, getFocusedElementIndex, setSearch, focusController } =
+    useSearch()
 
   return (
     <DefaultLayout
@@ -51,16 +40,12 @@ export default function HubPage({ hubId }: HubPageProps) {
         },
       }}
     >
-      {/* {!isInIframe && <WelcomeModal />} */}
-      <div className='flex flex-col'>
-        {searchResults.length === 0 && (
-          <NoChatsFound search={search} hubId={hubId} />
-        )}
-        <ChatPreviewList
-          chats={searchResults}
-          focusedElementIndex={focusedElementIndex}
-        />
-      </div>
+      <SearchContentWrapper
+        getFocusedElementIndex={getFocusedElementIndex}
+        search={search}
+      >
+        <ChatPreviewList chats={chats} />
+      </SearchContentWrapper>
     </DefaultLayout>
   )
 }

--- a/src/modules/chat/HubPage/HubPage.tsx
+++ b/src/modules/chat/HubPage/HubPage.tsx
@@ -41,6 +41,10 @@ export default function HubPage({ hubId }: HubPageProps) {
       }}
     >
       <SearchChannelsWrapper
+        localSearch={{
+          data: chats,
+          searchKeys: ['content.title'],
+        }}
         getFocusedElementIndex={getFocusedElementIndex}
         search={search}
       >

--- a/src/modules/chat/SearchChannelsWrapper.tsx
+++ b/src/modules/chat/SearchChannelsWrapper.tsx
@@ -1,29 +1,21 @@
 import ChatPreviewList from '@/components/chats/ChatPreviewList'
 import ChatPreviewSkeleton from '@/components/chats/ChatPreviewSkeleton'
-import ChatSpecialButtons from '@/components/chats/ChatSpecialButtons'
 import NoChatsFound from '@/components/chats/NoChatsFound'
 import useDebounce from '@/hooks/useDebounce'
-import useIsInIframe from '@/hooks/useIsInIframe'
 import useSearch from '@/hooks/useSearch'
 import { getPostsBySpaceContentQuery } from '@/services/subsocial/posts'
 
-export type SearchContentWrapperProps = {
+export type SearchChannelsWrapperProps = {
   children: JSX.Element
   search: string
-  showSpecialButtons?: boolean
-  isIntegrateChatButtonOnTop?: boolean
   getFocusedElementIndex: ReturnType<typeof useSearch>['getFocusedElementIndex']
 }
 
-export default function SearchContentWrapper({
-  isIntegrateChatButtonOnTop,
+export default function SearchChannelsWrapper({
   children,
   search,
-  showSpecialButtons,
   getFocusedElementIndex,
-}: SearchContentWrapperProps) {
-  const isInIframe = useIsInIframe()
-
+}: SearchChannelsWrapperProps) {
   const debouncedSearch = useDebounce(search)
   const { data: searchResults, isLoading } =
     getPostsBySpaceContentQuery.useQuery(search, {
@@ -31,16 +23,7 @@ export default function SearchContentWrapper({
     })
 
   if (!search) {
-    return (
-      <div className='flex flex-col'>
-        {showSpecialButtons && !isInIframe && (
-          <ChatSpecialButtons
-            isIntegrateChatButtonOnTop={!!isIntegrateChatButtonOnTop}
-          />
-        )}
-        {children}
-      </div>
-    )
+    return <div className='flex flex-col'>{children}</div>
   }
 
   if (isLoading) return <ChatPreviewSkeleton.SkeletonList />

--- a/src/modules/chat/SearchChannelsWrapper.tsx
+++ b/src/modules/chat/SearchChannelsWrapper.tsx
@@ -34,7 +34,7 @@ export default function SearchChannelsWrapper({
 
   let usedSearchResults = searchResults
   if (localSearch) {
-    const filteredData = searchResults?.filter(Boolean) ?? []
+    const filteredData = (localSearch.data?.filter(Boolean) ?? []) as PostData[]
     usedSearchResults = matchSorter(filteredData, cleanedSearch, {
       keys: localSearch.searchKeys,
     })

--- a/src/modules/chat/SearchChannelsWrapper.tsx
+++ b/src/modules/chat/SearchChannelsWrapper.tsx
@@ -3,7 +3,12 @@ import ChatPreviewSkeleton from '@/components/chats/ChatPreviewSkeleton'
 import NoChatsFound from '@/components/chats/NoChatsFound'
 import useDebounce from '@/hooks/useDebounce'
 import useSearch from '@/hooks/useSearch'
-import { getPostsBySpaceContentQuery } from '@/services/subsocial/posts'
+import { getPostQuery } from '@/services/api/query'
+import {
+  getPostIdsBySpaceIdQuery,
+  getPostsBySpaceContentQuery,
+} from '@/services/subsocial/posts'
+import { getMainHubId, getSquidUrl } from '@/utils/env/client'
 import { removeDoubleSpaces } from '@/utils/strings'
 import { PostData } from '@subsocial/api/types'
 import { matchSorter } from 'match-sorter'
@@ -26,11 +31,19 @@ export default function SearchChannelsWrapper({
 }: SearchChannelsWrapperProps) {
   const cleanedSearch = removeDoubleSpaces(search)
 
+  const isSquidAvailable = !!getSquidUrl()
+  const shouldUseGlobalSearch = !localSearch && isSquidAvailable
+
   const debouncedSearch = useDebounce(cleanedSearch)
   const { data: searchResults, isLoading } =
     getPostsBySpaceContentQuery.useQuery(cleanedSearch, {
-      enabled: !localSearch && cleanedSearch === debouncedSearch,
+      enabled: shouldUseGlobalSearch && cleanedSearch === debouncedSearch,
     })
+
+  const { data: mainPostIds } = getPostIdsBySpaceIdQuery.useQuery(
+    getMainHubId()
+  )
+  const mainPostsQueries = getPostQuery.useQueries(mainPostIds?.postIds ?? [])
 
   let usedSearchResults = searchResults
   if (localSearch) {
@@ -38,13 +51,21 @@ export default function SearchChannelsWrapper({
     usedSearchResults = matchSorter(filteredData, cleanedSearch, {
       keys: localSearch.searchKeys,
     })
+  } else if (!isSquidAvailable) {
+    const mainPosts = mainPostsQueries
+      .map(({ data }) => data)
+      .filter(Boolean) as PostData[]
+    usedSearchResults = matchSorter(mainPosts, cleanedSearch, {
+      keys: ['content.title'],
+    })
   }
 
   if (!cleanedSearch) {
     return <div className='flex flex-col'>{children}</div>
   }
 
-  if (!localSearch && isLoading) return <ChatPreviewSkeleton.SkeletonList />
+  if (isLoading && shouldUseGlobalSearch)
+    return <ChatPreviewSkeleton.SkeletonList />
 
   if (!usedSearchResults || usedSearchResults.length === 0) {
     return <NoChatsFound search={search} />

--- a/src/modules/chat/SearchChannelsWrapper.tsx
+++ b/src/modules/chat/SearchChannelsWrapper.tsx
@@ -44,7 +44,7 @@ export default function SearchChannelsWrapper({
     return <div className='flex flex-col'>{children}</div>
   }
 
-  if (isLoading) return <ChatPreviewSkeleton.SkeletonList />
+  if (!localSearch && isLoading) return <ChatPreviewSkeleton.SkeletonList />
 
   if (!usedSearchResults || usedSearchResults.length === 0) {
     return <NoChatsFound search={search} />

--- a/src/modules/chat/SearchContentWrapper.tsx
+++ b/src/modules/chat/SearchContentWrapper.tsx
@@ -2,6 +2,7 @@ import ChatPreviewList from '@/components/chats/ChatPreviewList'
 import ChatPreviewSkeleton from '@/components/chats/ChatPreviewSkeleton'
 import ChatSpecialButtons from '@/components/chats/ChatSpecialButtons'
 import NoChatsFound from '@/components/chats/NoChatsFound'
+import useDebounce from '@/hooks/useDebounce'
 import useIsInIframe from '@/hooks/useIsInIframe'
 import useSearch from '@/hooks/useSearch'
 import { getPostsBySpaceContentQuery } from '@/services/subsocial/posts'
@@ -22,8 +23,12 @@ export default function SearchContentWrapper({
   getFocusedElementIndex,
 }: SearchContentWrapperProps) {
   const isInIframe = useIsInIframe()
+
+  const debouncedSearch = useDebounce(search)
   const { data: searchResults, isLoading } =
-    getPostsBySpaceContentQuery.useQuery(search)
+    getPostsBySpaceContentQuery.useQuery(search, {
+      enabled: search === debouncedSearch,
+    })
 
   if (!search) {
     return (

--- a/src/modules/chat/SearchContentWrapper.tsx
+++ b/src/modules/chat/SearchContentWrapper.tsx
@@ -1,0 +1,53 @@
+import ChatPreviewList from '@/components/chats/ChatPreviewList'
+import ChatPreviewSkeleton from '@/components/chats/ChatPreviewSkeleton'
+import ChatSpecialButtons from '@/components/chats/ChatSpecialButtons'
+import NoChatsFound from '@/components/chats/NoChatsFound'
+import useIsInIframe from '@/hooks/useIsInIframe'
+import useSearch from '@/hooks/useSearch'
+import { getPostsBySpaceContentQuery } from '@/services/subsocial/posts'
+
+export type SearchContentWrapperProps = {
+  children: JSX.Element
+  search: string
+  showSpecialButtons?: boolean
+  isIntegrateChatButtonOnTop?: boolean
+  getFocusedElementIndex: ReturnType<typeof useSearch>['getFocusedElementIndex']
+}
+
+export default function SearchContentWrapper({
+  isIntegrateChatButtonOnTop,
+  children,
+  search,
+  showSpecialButtons,
+  getFocusedElementIndex,
+}: SearchContentWrapperProps) {
+  const isInIframe = useIsInIframe()
+  const { data: searchResults, isLoading } =
+    getPostsBySpaceContentQuery.useQuery(search)
+
+  if (!search) {
+    return (
+      <div className='flex flex-col'>
+        {showSpecialButtons && !isInIframe && (
+          <ChatSpecialButtons
+            isIntegrateChatButtonOnTop={!!isIntegrateChatButtonOnTop}
+          />
+        )}
+        {children}
+      </div>
+    )
+  }
+
+  if (isLoading) return <ChatPreviewSkeleton.SkeletonList />
+
+  if (!searchResults || searchResults.length === 0) {
+    return <NoChatsFound search={search} />
+  }
+
+  return (
+    <ChatPreviewList
+      chats={searchResults}
+      focusedElementIndex={getFocusedElementIndex(searchResults)}
+    />
+  )
+}

--- a/src/services/subsocial/posts/query.ts
+++ b/src/services/subsocial/posts/query.ts
@@ -4,6 +4,7 @@ import {
   createSubsocialQuery,
   SubsocialQueryData,
 } from '@/subsocial-query/subsocial/query'
+import { getHubIds } from '@/utils/env/client'
 import { gql } from 'graphql-request'
 import { POST_FRAGMENT } from '../squid/fragments'
 import {
@@ -83,15 +84,13 @@ export const getFollowedPostIdsByAddressQuery = createSubsocialQuery({
 
 export const GET_POSTS_BY_CONTENT = gql`
   ${POST_FRAGMENT}
-  query getPostsByContent($search: String!) {
+  query getPostsByContent($search: String!, $spaceIds: [String!]!) {
     posts(
       where: {
         hidden_eq: false
         isComment_eq: false
-        AND: {
-          title_containsInsensitive: $search
-          OR: { body_containsInsensitive: $search }
-        }
+        title_containsInsensitive: $search
+        space: { id_in: $spaceIds }
       }
     ) {
       ...PostFragment
@@ -105,7 +104,7 @@ async function getPostsByContent(search: string) {
     GetPostsByContentQueryVariables
   >({
     document: GET_POSTS_BY_CONTENT,
-    variables: { search },
+    variables: { search, spaceIds: getHubIds() },
   })
   return res.posts.map((post) => mapPostFragment(post))
 }

--- a/src/services/subsocial/spaces/query.ts
+++ b/src/services/subsocial/spaces/query.ts
@@ -42,6 +42,10 @@ const getSpaceFromSquid = poolQuery<string, SpaceData>({
     })
     return res.spaces.map((space) => mapSpaceFragment(space))
   },
+  resultMapper: {
+    paramToKey: (param) => param,
+    resultToKey: (result) => result?.id ?? '',
+  },
 })
 
 export const getSpaceQuery = createDynamicSubsocialQuery('getSpace', {

--- a/src/services/subsocial/squid/generated.ts
+++ b/src/services/subsocial/squid/generated.ts
@@ -23,6 +23,7 @@ export type Account = {
   __typename?: 'Account';
   /** A One-To-Many relationship with the Activities which have been performed by an Account (foreign key - "account") */
   activities: Array<Activity>;
+  extensions: Array<ContentExtension>;
   /**
    * A One-To-Many relationship between an Account and the Activities it has performed in the network through NewsFeed (foreign key - "account").
    * Each Activity has the "event<EventName>" and "post" fields, which can be used for adding created Posts to a user's Feed.
@@ -42,6 +43,8 @@ export type Account = {
   followingSpacesCount: Scalars['Int']['output'];
   /** The account's public key converted to ss58 format for the Subsocial chain (prefix "28") */
   id: Scalars['String']['output'];
+  /** A list of linked Evm Accounts */
+  linkedEvmAccounts: Array<EvmSubstrateAccountLink>;
   /** A Many-To-Many relationship between an Account and Activities done in the network through Notification (foreign key - "account"). */
   notifications: Array<Notification>;
   /** A One-To-Many relationship with the Posts which are owned by an Account (foreign key - "ownedByAccount") */
@@ -79,6 +82,15 @@ export type AccountActivitiesArgs = {
 
 
 /** The Account entity */
+export type AccountExtensionsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Array<ContentExtensionOrderByInput>>;
+  where?: InputMaybe<ContentExtensionWhereInput>;
+};
+
+
+/** The Account entity */
 export type AccountFeedsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
@@ -102,6 +114,15 @@ export type AccountFollowingAccountsArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<AccountFollowersOrderByInput>>;
   where?: InputMaybe<AccountFollowersWhereInput>;
+};
+
+
+/** The Account entity */
+export type AccountLinkedEvmAccountsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Array<EvmSubstrateAccountLinkOrderByInput>>;
+  where?: InputMaybe<EvmSubstrateAccountLinkWhereInput>;
 };
 
 
@@ -334,6 +355,9 @@ export type AccountWhereInput = {
   activities_every?: InputMaybe<ActivityWhereInput>;
   activities_none?: InputMaybe<ActivityWhereInput>;
   activities_some?: InputMaybe<ActivityWhereInput>;
+  extensions_every?: InputMaybe<ContentExtensionWhereInput>;
+  extensions_none?: InputMaybe<ContentExtensionWhereInput>;
+  extensions_some?: InputMaybe<ContentExtensionWhereInput>;
   feeds_every?: InputMaybe<NewsFeedWhereInput>;
   feeds_none?: InputMaybe<NewsFeedWhereInput>;
   feeds_some?: InputMaybe<NewsFeedWhereInput>;
@@ -396,6 +420,9 @@ export type AccountWhereInput = {
   id_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
   id_not_startsWith?: InputMaybe<Scalars['String']['input']>;
   id_startsWith?: InputMaybe<Scalars['String']['input']>;
+  linkedEvmAccounts_every?: InputMaybe<EvmSubstrateAccountLinkWhereInput>;
+  linkedEvmAccounts_none?: InputMaybe<EvmSubstrateAccountLinkWhereInput>;
+  linkedEvmAccounts_some?: InputMaybe<EvmSubstrateAccountLinkWhereInput>;
   notifications_every?: InputMaybe<NotificationWhereInput>;
   notifications_none?: InputMaybe<NotificationWhereInput>;
   notifications_some?: InputMaybe<NotificationWhereInput>;
@@ -483,6 +510,8 @@ export type Activity = {
   event: EventName;
   /** The event's index in the block */
   eventIndex: Scalars['Int']['output'];
+  /** The ContentExtension which was created in this particular Activity. */
+  extension?: Maybe<ContentExtension>;
   /** A One-to-One relationship with the following Account if the event is `AccountFollowed` or `AccountUnfollowed`. */
   followingAccount?: Maybe<Account>;
   /** The ID of an Activity. It has the following structure: <blockNumber>-<indexInBlock>-<md5Hash(eventName)>` (e.g. 1093209-1001-1ee8fd8482c322254acff29a8f52f5e1) */
@@ -538,6 +567,26 @@ export enum ActivityOrderByInput {
   EventIndexDesc = 'eventIndex_DESC',
   EventAsc = 'event_ASC',
   EventDesc = 'event_DESC',
+  ExtensionAmountAsc = 'extension_amount_ASC',
+  ExtensionAmountDesc = 'extension_amount_DESC',
+  ExtensionChainAsc = 'extension_chain_ASC',
+  ExtensionChainDesc = 'extension_chain_DESC',
+  ExtensionCollectionIdAsc = 'extension_collectionId_ASC',
+  ExtensionCollectionIdDesc = 'extension_collectionId_DESC',
+  ExtensionDecimalsAsc = 'extension_decimals_ASC',
+  ExtensionDecimalsDesc = 'extension_decimals_DESC',
+  ExtensionExtensionSchemaIdAsc = 'extension_extensionSchemaId_ASC',
+  ExtensionExtensionSchemaIdDesc = 'extension_extensionSchemaId_DESC',
+  ExtensionIdAsc = 'extension_id_ASC',
+  ExtensionIdDesc = 'extension_id_DESC',
+  ExtensionNftIdAsc = 'extension_nftId_ASC',
+  ExtensionNftIdDesc = 'extension_nftId_DESC',
+  ExtensionTokenAsc = 'extension_token_ASC',
+  ExtensionTokenDesc = 'extension_token_DESC',
+  ExtensionTxHashAsc = 'extension_txHash_ASC',
+  ExtensionTxHashDesc = 'extension_txHash_DESC',
+  ExtensionUrlAsc = 'extension_url_ASC',
+  ExtensionUrlDesc = 'extension_url_DESC',
   FollowingAccountFollowersCountAsc = 'followingAccount_followersCount_ASC',
   FollowingAccountFollowersCountDesc = 'followingAccount_followersCount_DESC',
   FollowingAccountFollowingAccountsCountAsc = 'followingAccount_followingAccountsCount_ASC',
@@ -819,6 +868,8 @@ export type ActivityWhereInput = {
   event_isNull?: InputMaybe<Scalars['Boolean']['input']>;
   event_not_eq?: InputMaybe<EventName>;
   event_not_in?: InputMaybe<Array<EventName>>;
+  extension?: InputMaybe<ContentExtensionWhereInput>;
+  extension_isNull?: InputMaybe<Scalars['Boolean']['input']>;
   followingAccount?: InputMaybe<AccountWhereInput>;
   followingAccount_isNull?: InputMaybe<Scalars['Boolean']['input']>;
   id_contains?: InputMaybe<Scalars['String']['input']>;
@@ -997,6 +1048,338 @@ export type CommentFollowersWhereInput = {
   id_startsWith?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type ContentExtension = {
+  __typename?: 'ContentExtension';
+  amount?: Maybe<Scalars['BigInt']['output']>;
+  chain?: Maybe<Scalars['String']['output']>;
+  collectionId?: Maybe<Scalars['String']['output']>;
+  createdBy: Account;
+  decimals?: Maybe<Scalars['Int']['output']>;
+  extensionSchemaId: ContentExtensionSchemaId;
+  fromEvm?: Maybe<EvmAccount>;
+  fromSubstrate?: Maybe<Account>;
+  id: Scalars['String']['output'];
+  nftId?: Maybe<Scalars['String']['output']>;
+  parentPost: Post;
+  toEvm?: Maybe<EvmAccount>;
+  toSubstrate?: Maybe<Account>;
+  token?: Maybe<Scalars['String']['output']>;
+  txHash?: Maybe<Scalars['String']['output']>;
+  url?: Maybe<Scalars['String']['output']>;
+};
+
+export type ContentExtensionEdge = {
+  __typename?: 'ContentExtensionEdge';
+  cursor: Scalars['String']['output'];
+  node: ContentExtension;
+};
+
+export enum ContentExtensionOrderByInput {
+  AmountAsc = 'amount_ASC',
+  AmountDesc = 'amount_DESC',
+  ChainAsc = 'chain_ASC',
+  ChainDesc = 'chain_DESC',
+  CollectionIdAsc = 'collectionId_ASC',
+  CollectionIdDesc = 'collectionId_DESC',
+  CreatedByFollowersCountAsc = 'createdBy_followersCount_ASC',
+  CreatedByFollowersCountDesc = 'createdBy_followersCount_DESC',
+  CreatedByFollowingAccountsCountAsc = 'createdBy_followingAccountsCount_ASC',
+  CreatedByFollowingAccountsCountDesc = 'createdBy_followingAccountsCount_DESC',
+  CreatedByFollowingPostsCountAsc = 'createdBy_followingPostsCount_ASC',
+  CreatedByFollowingPostsCountDesc = 'createdBy_followingPostsCount_DESC',
+  CreatedByFollowingSpacesCountAsc = 'createdBy_followingSpacesCount_ASC',
+  CreatedByFollowingSpacesCountDesc = 'createdBy_followingSpacesCount_DESC',
+  CreatedByIdAsc = 'createdBy_id_ASC',
+  CreatedByIdDesc = 'createdBy_id_DESC',
+  CreatedByOwnedPostsCountAsc = 'createdBy_ownedPostsCount_ASC',
+  CreatedByOwnedPostsCountDesc = 'createdBy_ownedPostsCount_DESC',
+  CreatedByUpdatedAtBlockAsc = 'createdBy_updatedAtBlock_ASC',
+  CreatedByUpdatedAtBlockDesc = 'createdBy_updatedAtBlock_DESC',
+  CreatedByUpdatedAtTimeAsc = 'createdBy_updatedAtTime_ASC',
+  CreatedByUpdatedAtTimeDesc = 'createdBy_updatedAtTime_DESC',
+  DecimalsAsc = 'decimals_ASC',
+  DecimalsDesc = 'decimals_DESC',
+  ExtensionSchemaIdAsc = 'extensionSchemaId_ASC',
+  ExtensionSchemaIdDesc = 'extensionSchemaId_DESC',
+  FromEvmIdAsc = 'fromEvm_id_ASC',
+  FromEvmIdDesc = 'fromEvm_id_DESC',
+  FromSubstrateFollowersCountAsc = 'fromSubstrate_followersCount_ASC',
+  FromSubstrateFollowersCountDesc = 'fromSubstrate_followersCount_DESC',
+  FromSubstrateFollowingAccountsCountAsc = 'fromSubstrate_followingAccountsCount_ASC',
+  FromSubstrateFollowingAccountsCountDesc = 'fromSubstrate_followingAccountsCount_DESC',
+  FromSubstrateFollowingPostsCountAsc = 'fromSubstrate_followingPostsCount_ASC',
+  FromSubstrateFollowingPostsCountDesc = 'fromSubstrate_followingPostsCount_DESC',
+  FromSubstrateFollowingSpacesCountAsc = 'fromSubstrate_followingSpacesCount_ASC',
+  FromSubstrateFollowingSpacesCountDesc = 'fromSubstrate_followingSpacesCount_DESC',
+  FromSubstrateIdAsc = 'fromSubstrate_id_ASC',
+  FromSubstrateIdDesc = 'fromSubstrate_id_DESC',
+  FromSubstrateOwnedPostsCountAsc = 'fromSubstrate_ownedPostsCount_ASC',
+  FromSubstrateOwnedPostsCountDesc = 'fromSubstrate_ownedPostsCount_DESC',
+  FromSubstrateUpdatedAtBlockAsc = 'fromSubstrate_updatedAtBlock_ASC',
+  FromSubstrateUpdatedAtBlockDesc = 'fromSubstrate_updatedAtBlock_DESC',
+  FromSubstrateUpdatedAtTimeAsc = 'fromSubstrate_updatedAtTime_ASC',
+  FromSubstrateUpdatedAtTimeDesc = 'fromSubstrate_updatedAtTime_DESC',
+  IdAsc = 'id_ASC',
+  IdDesc = 'id_DESC',
+  NftIdAsc = 'nftId_ASC',
+  NftIdDesc = 'nftId_DESC',
+  ParentPostBodyAsc = 'parentPost_body_ASC',
+  ParentPostBodyDesc = 'parentPost_body_DESC',
+  ParentPostCanonicalAsc = 'parentPost_canonical_ASC',
+  ParentPostCanonicalDesc = 'parentPost_canonical_DESC',
+  ParentPostContentAsc = 'parentPost_content_ASC',
+  ParentPostContentDesc = 'parentPost_content_DESC',
+  ParentPostCreatedAtBlockAsc = 'parentPost_createdAtBlock_ASC',
+  ParentPostCreatedAtBlockDesc = 'parentPost_createdAtBlock_DESC',
+  ParentPostCreatedAtTimeAsc = 'parentPost_createdAtTime_ASC',
+  ParentPostCreatedAtTimeDesc = 'parentPost_createdAtTime_DESC',
+  ParentPostCreatedOnDayAsc = 'parentPost_createdOnDay_ASC',
+  ParentPostCreatedOnDayDesc = 'parentPost_createdOnDay_DESC',
+  ParentPostDownvotesCountAsc = 'parentPost_downvotesCount_ASC',
+  ParentPostDownvotesCountDesc = 'parentPost_downvotesCount_DESC',
+  ParentPostFollowersCountAsc = 'parentPost_followersCount_ASC',
+  ParentPostFollowersCountDesc = 'parentPost_followersCount_DESC',
+  ParentPostFormatAsc = 'parentPost_format_ASC',
+  ParentPostFormatDesc = 'parentPost_format_DESC',
+  ParentPostHiddenRepliesCountAsc = 'parentPost_hiddenRepliesCount_ASC',
+  ParentPostHiddenRepliesCountDesc = 'parentPost_hiddenRepliesCount_DESC',
+  ParentPostHiddenAsc = 'parentPost_hidden_ASC',
+  ParentPostHiddenDesc = 'parentPost_hidden_DESC',
+  ParentPostIdAsc = 'parentPost_id_ASC',
+  ParentPostIdDesc = 'parentPost_id_DESC',
+  ParentPostImageAsc = 'parentPost_image_ASC',
+  ParentPostImageDesc = 'parentPost_image_DESC',
+  ParentPostIsCommentAsc = 'parentPost_isComment_ASC',
+  ParentPostIsCommentDesc = 'parentPost_isComment_DESC',
+  ParentPostIsShowMoreAsc = 'parentPost_isShowMore_ASC',
+  ParentPostIsShowMoreDesc = 'parentPost_isShowMore_DESC',
+  ParentPostKindAsc = 'parentPost_kind_ASC',
+  ParentPostKindDesc = 'parentPost_kind_DESC',
+  ParentPostLinkAsc = 'parentPost_link_ASC',
+  ParentPostLinkDesc = 'parentPost_link_DESC',
+  ParentPostMetaAsc = 'parentPost_meta_ASC',
+  ParentPostMetaDesc = 'parentPost_meta_DESC',
+  ParentPostProposalIndexAsc = 'parentPost_proposalIndex_ASC',
+  ParentPostProposalIndexDesc = 'parentPost_proposalIndex_DESC',
+  ParentPostPublicRepliesCountAsc = 'parentPost_publicRepliesCount_ASC',
+  ParentPostPublicRepliesCountDesc = 'parentPost_publicRepliesCount_DESC',
+  ParentPostReactionsCountAsc = 'parentPost_reactionsCount_ASC',
+  ParentPostReactionsCountDesc = 'parentPost_reactionsCount_DESC',
+  ParentPostRepliesCountAsc = 'parentPost_repliesCount_ASC',
+  ParentPostRepliesCountDesc = 'parentPost_repliesCount_DESC',
+  ParentPostSharesCountAsc = 'parentPost_sharesCount_ASC',
+  ParentPostSharesCountDesc = 'parentPost_sharesCount_DESC',
+  ParentPostSlugAsc = 'parentPost_slug_ASC',
+  ParentPostSlugDesc = 'parentPost_slug_DESC',
+  ParentPostSummaryAsc = 'parentPost_summary_ASC',
+  ParentPostSummaryDesc = 'parentPost_summary_DESC',
+  ParentPostTagsOriginalAsc = 'parentPost_tagsOriginal_ASC',
+  ParentPostTagsOriginalDesc = 'parentPost_tagsOriginal_DESC',
+  ParentPostTitleAsc = 'parentPost_title_ASC',
+  ParentPostTitleDesc = 'parentPost_title_DESC',
+  ParentPostTweetIdAsc = 'parentPost_tweetId_ASC',
+  ParentPostTweetIdDesc = 'parentPost_tweetId_DESC',
+  ParentPostUpdatedAtTimeAsc = 'parentPost_updatedAtTime_ASC',
+  ParentPostUpdatedAtTimeDesc = 'parentPost_updatedAtTime_DESC',
+  ParentPostUpvotesCountAsc = 'parentPost_upvotesCount_ASC',
+  ParentPostUpvotesCountDesc = 'parentPost_upvotesCount_DESC',
+  ToEvmIdAsc = 'toEvm_id_ASC',
+  ToEvmIdDesc = 'toEvm_id_DESC',
+  ToSubstrateFollowersCountAsc = 'toSubstrate_followersCount_ASC',
+  ToSubstrateFollowersCountDesc = 'toSubstrate_followersCount_DESC',
+  ToSubstrateFollowingAccountsCountAsc = 'toSubstrate_followingAccountsCount_ASC',
+  ToSubstrateFollowingAccountsCountDesc = 'toSubstrate_followingAccountsCount_DESC',
+  ToSubstrateFollowingPostsCountAsc = 'toSubstrate_followingPostsCount_ASC',
+  ToSubstrateFollowingPostsCountDesc = 'toSubstrate_followingPostsCount_DESC',
+  ToSubstrateFollowingSpacesCountAsc = 'toSubstrate_followingSpacesCount_ASC',
+  ToSubstrateFollowingSpacesCountDesc = 'toSubstrate_followingSpacesCount_DESC',
+  ToSubstrateIdAsc = 'toSubstrate_id_ASC',
+  ToSubstrateIdDesc = 'toSubstrate_id_DESC',
+  ToSubstrateOwnedPostsCountAsc = 'toSubstrate_ownedPostsCount_ASC',
+  ToSubstrateOwnedPostsCountDesc = 'toSubstrate_ownedPostsCount_DESC',
+  ToSubstrateUpdatedAtBlockAsc = 'toSubstrate_updatedAtBlock_ASC',
+  ToSubstrateUpdatedAtBlockDesc = 'toSubstrate_updatedAtBlock_DESC',
+  ToSubstrateUpdatedAtTimeAsc = 'toSubstrate_updatedAtTime_ASC',
+  ToSubstrateUpdatedAtTimeDesc = 'toSubstrate_updatedAtTime_DESC',
+  TokenAsc = 'token_ASC',
+  TokenDesc = 'token_DESC',
+  TxHashAsc = 'txHash_ASC',
+  TxHashDesc = 'txHash_DESC',
+  UrlAsc = 'url_ASC',
+  UrlDesc = 'url_DESC'
+}
+
+export enum ContentExtensionSchemaId {
+  SubsocialDonations = 'subsocial_donations',
+  SubsocialEvmNft = 'subsocial_evm_nft'
+}
+
+export type ContentExtensionWhereInput = {
+  AND?: InputMaybe<Array<ContentExtensionWhereInput>>;
+  OR?: InputMaybe<Array<ContentExtensionWhereInput>>;
+  amount_eq?: InputMaybe<Scalars['BigInt']['input']>;
+  amount_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  amount_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  amount_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  amount_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  amount_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  amount_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  amount_not_eq?: InputMaybe<Scalars['BigInt']['input']>;
+  amount_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  chain_contains?: InputMaybe<Scalars['String']['input']>;
+  chain_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  chain_endsWith?: InputMaybe<Scalars['String']['input']>;
+  chain_eq?: InputMaybe<Scalars['String']['input']>;
+  chain_gt?: InputMaybe<Scalars['String']['input']>;
+  chain_gte?: InputMaybe<Scalars['String']['input']>;
+  chain_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  chain_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  chain_lt?: InputMaybe<Scalars['String']['input']>;
+  chain_lte?: InputMaybe<Scalars['String']['input']>;
+  chain_not_contains?: InputMaybe<Scalars['String']['input']>;
+  chain_not_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  chain_not_endsWith?: InputMaybe<Scalars['String']['input']>;
+  chain_not_eq?: InputMaybe<Scalars['String']['input']>;
+  chain_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  chain_not_startsWith?: InputMaybe<Scalars['String']['input']>;
+  chain_startsWith?: InputMaybe<Scalars['String']['input']>;
+  collectionId_contains?: InputMaybe<Scalars['String']['input']>;
+  collectionId_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  collectionId_endsWith?: InputMaybe<Scalars['String']['input']>;
+  collectionId_eq?: InputMaybe<Scalars['String']['input']>;
+  collectionId_gt?: InputMaybe<Scalars['String']['input']>;
+  collectionId_gte?: InputMaybe<Scalars['String']['input']>;
+  collectionId_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  collectionId_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  collectionId_lt?: InputMaybe<Scalars['String']['input']>;
+  collectionId_lte?: InputMaybe<Scalars['String']['input']>;
+  collectionId_not_contains?: InputMaybe<Scalars['String']['input']>;
+  collectionId_not_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  collectionId_not_endsWith?: InputMaybe<Scalars['String']['input']>;
+  collectionId_not_eq?: InputMaybe<Scalars['String']['input']>;
+  collectionId_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  collectionId_not_startsWith?: InputMaybe<Scalars['String']['input']>;
+  collectionId_startsWith?: InputMaybe<Scalars['String']['input']>;
+  createdBy?: InputMaybe<AccountWhereInput>;
+  createdBy_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  decimals_eq?: InputMaybe<Scalars['Int']['input']>;
+  decimals_gt?: InputMaybe<Scalars['Int']['input']>;
+  decimals_gte?: InputMaybe<Scalars['Int']['input']>;
+  decimals_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  decimals_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  decimals_lt?: InputMaybe<Scalars['Int']['input']>;
+  decimals_lte?: InputMaybe<Scalars['Int']['input']>;
+  decimals_not_eq?: InputMaybe<Scalars['Int']['input']>;
+  decimals_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  extensionSchemaId_eq?: InputMaybe<ContentExtensionSchemaId>;
+  extensionSchemaId_in?: InputMaybe<Array<ContentExtensionSchemaId>>;
+  extensionSchemaId_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  extensionSchemaId_not_eq?: InputMaybe<ContentExtensionSchemaId>;
+  extensionSchemaId_not_in?: InputMaybe<Array<ContentExtensionSchemaId>>;
+  fromEvm?: InputMaybe<EvmAccountWhereInput>;
+  fromEvm_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  fromSubstrate?: InputMaybe<AccountWhereInput>;
+  fromSubstrate_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  id_contains?: InputMaybe<Scalars['String']['input']>;
+  id_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  id_endsWith?: InputMaybe<Scalars['String']['input']>;
+  id_eq?: InputMaybe<Scalars['String']['input']>;
+  id_gt?: InputMaybe<Scalars['String']['input']>;
+  id_gte?: InputMaybe<Scalars['String']['input']>;
+  id_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  id_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  id_lt?: InputMaybe<Scalars['String']['input']>;
+  id_lte?: InputMaybe<Scalars['String']['input']>;
+  id_not_contains?: InputMaybe<Scalars['String']['input']>;
+  id_not_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  id_not_endsWith?: InputMaybe<Scalars['String']['input']>;
+  id_not_eq?: InputMaybe<Scalars['String']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  id_not_startsWith?: InputMaybe<Scalars['String']['input']>;
+  id_startsWith?: InputMaybe<Scalars['String']['input']>;
+  nftId_contains?: InputMaybe<Scalars['String']['input']>;
+  nftId_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  nftId_endsWith?: InputMaybe<Scalars['String']['input']>;
+  nftId_eq?: InputMaybe<Scalars['String']['input']>;
+  nftId_gt?: InputMaybe<Scalars['String']['input']>;
+  nftId_gte?: InputMaybe<Scalars['String']['input']>;
+  nftId_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  nftId_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  nftId_lt?: InputMaybe<Scalars['String']['input']>;
+  nftId_lte?: InputMaybe<Scalars['String']['input']>;
+  nftId_not_contains?: InputMaybe<Scalars['String']['input']>;
+  nftId_not_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  nftId_not_endsWith?: InputMaybe<Scalars['String']['input']>;
+  nftId_not_eq?: InputMaybe<Scalars['String']['input']>;
+  nftId_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  nftId_not_startsWith?: InputMaybe<Scalars['String']['input']>;
+  nftId_startsWith?: InputMaybe<Scalars['String']['input']>;
+  parentPost?: InputMaybe<PostWhereInput>;
+  parentPost_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  toEvm?: InputMaybe<EvmAccountWhereInput>;
+  toEvm_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  toSubstrate?: InputMaybe<AccountWhereInput>;
+  toSubstrate_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  token_contains?: InputMaybe<Scalars['String']['input']>;
+  token_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  token_endsWith?: InputMaybe<Scalars['String']['input']>;
+  token_eq?: InputMaybe<Scalars['String']['input']>;
+  token_gt?: InputMaybe<Scalars['String']['input']>;
+  token_gte?: InputMaybe<Scalars['String']['input']>;
+  token_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  token_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  token_lt?: InputMaybe<Scalars['String']['input']>;
+  token_lte?: InputMaybe<Scalars['String']['input']>;
+  token_not_contains?: InputMaybe<Scalars['String']['input']>;
+  token_not_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  token_not_endsWith?: InputMaybe<Scalars['String']['input']>;
+  token_not_eq?: InputMaybe<Scalars['String']['input']>;
+  token_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  token_not_startsWith?: InputMaybe<Scalars['String']['input']>;
+  token_startsWith?: InputMaybe<Scalars['String']['input']>;
+  txHash_contains?: InputMaybe<Scalars['String']['input']>;
+  txHash_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  txHash_endsWith?: InputMaybe<Scalars['String']['input']>;
+  txHash_eq?: InputMaybe<Scalars['String']['input']>;
+  txHash_gt?: InputMaybe<Scalars['String']['input']>;
+  txHash_gte?: InputMaybe<Scalars['String']['input']>;
+  txHash_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  txHash_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  txHash_lt?: InputMaybe<Scalars['String']['input']>;
+  txHash_lte?: InputMaybe<Scalars['String']['input']>;
+  txHash_not_contains?: InputMaybe<Scalars['String']['input']>;
+  txHash_not_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  txHash_not_endsWith?: InputMaybe<Scalars['String']['input']>;
+  txHash_not_eq?: InputMaybe<Scalars['String']['input']>;
+  txHash_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  txHash_not_startsWith?: InputMaybe<Scalars['String']['input']>;
+  txHash_startsWith?: InputMaybe<Scalars['String']['input']>;
+  url_contains?: InputMaybe<Scalars['String']['input']>;
+  url_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  url_endsWith?: InputMaybe<Scalars['String']['input']>;
+  url_eq?: InputMaybe<Scalars['String']['input']>;
+  url_gt?: InputMaybe<Scalars['String']['input']>;
+  url_gte?: InputMaybe<Scalars['String']['input']>;
+  url_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  url_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  url_lt?: InputMaybe<Scalars['String']['input']>;
+  url_lte?: InputMaybe<Scalars['String']['input']>;
+  url_not_contains?: InputMaybe<Scalars['String']['input']>;
+  url_not_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  url_not_endsWith?: InputMaybe<Scalars['String']['input']>;
+  url_not_eq?: InputMaybe<Scalars['String']['input']>;
+  url_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  url_not_startsWith?: InputMaybe<Scalars['String']['input']>;
+  url_startsWith?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ContentExtensionsConnection = {
+  __typename?: 'ContentExtensionsConnection';
+  edges: Array<ContentExtensionEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
 export type EsError = {
   __typename?: 'ESError';
   /** Error message text message. */
@@ -1041,6 +1424,8 @@ export type ElasticSearchQueryResultEntity = {
  *   * AccountFollows.AccountUnfollowed
  *   * Domains.DomainRegistered
  *   * Domains.DomainMetaUpdated
+ *   * EvmAddressUnlinkedFromAccount
+ *   * EvmAddressLinkedToAccount
  *
  * ***
  *
@@ -1086,6 +1471,10 @@ export type ElasticSearchQueryResultEntity = {
  * * CommentReplyReactionDeleted - *synthetic*
  * * UserNameRegistered - *synthetic*
  * * UserNameUpdated - *synthetic*
+ * * ExtensionDonationCreated - *synthetic*
+ * * ExtensionEvmNftShared - *synthetic*
+ * * EvmAddressLinkedToAccount
+ * * EvmAddressUnlinkedFromAccount
  */
 export enum EventName {
   AccountFollowed = 'AccountFollowed',
@@ -1104,6 +1493,10 @@ export enum EventName {
   CommentReplyUpdated = 'CommentReplyUpdated',
   CommentShared = 'CommentShared',
   CommentUpdated = 'CommentUpdated',
+  EvmAddressLinkedToAccount = 'EvmAddressLinkedToAccount',
+  EvmAddressUnlinkedFromAccount = 'EvmAddressUnlinkedFromAccount',
+  ExtensionDonationCreated = 'ExtensionDonationCreated',
+  ExtensionEvmNftShared = 'ExtensionEvmNftShared',
   PostCreated = 'PostCreated',
   PostDeleted = 'PostDeleted',
   PostFollowed = 'PostFollowed',
@@ -1124,6 +1517,169 @@ export enum EventName {
   UserNameRegistered = 'UserNameRegistered',
   UserNameUpdated = 'UserNameUpdated'
 }
+
+/** The Account entity */
+export type EvmAccount = {
+  __typename?: 'EvmAccount';
+  /** The account's public key */
+  id: Scalars['String']['output'];
+  /** A list of linked Substrate Accounts */
+  linkedSubstrateAccounts: Array<EvmSubstrateAccountLink>;
+};
+
+
+/** The Account entity */
+export type EvmAccountLinkedSubstrateAccountsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Array<EvmSubstrateAccountLinkOrderByInput>>;
+  where?: InputMaybe<EvmSubstrateAccountLinkWhereInput>;
+};
+
+export type EvmAccountEdge = {
+  __typename?: 'EvmAccountEdge';
+  cursor: Scalars['String']['output'];
+  node: EvmAccount;
+};
+
+export enum EvmAccountOrderByInput {
+  IdAsc = 'id_ASC',
+  IdDesc = 'id_DESC'
+}
+
+export type EvmAccountWhereInput = {
+  AND?: InputMaybe<Array<EvmAccountWhereInput>>;
+  OR?: InputMaybe<Array<EvmAccountWhereInput>>;
+  id_contains?: InputMaybe<Scalars['String']['input']>;
+  id_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  id_endsWith?: InputMaybe<Scalars['String']['input']>;
+  id_eq?: InputMaybe<Scalars['String']['input']>;
+  id_gt?: InputMaybe<Scalars['String']['input']>;
+  id_gte?: InputMaybe<Scalars['String']['input']>;
+  id_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  id_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  id_lt?: InputMaybe<Scalars['String']['input']>;
+  id_lte?: InputMaybe<Scalars['String']['input']>;
+  id_not_contains?: InputMaybe<Scalars['String']['input']>;
+  id_not_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  id_not_endsWith?: InputMaybe<Scalars['String']['input']>;
+  id_not_eq?: InputMaybe<Scalars['String']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  id_not_startsWith?: InputMaybe<Scalars['String']['input']>;
+  id_startsWith?: InputMaybe<Scalars['String']['input']>;
+  linkedSubstrateAccounts_every?: InputMaybe<EvmSubstrateAccountLinkWhereInput>;
+  linkedSubstrateAccounts_none?: InputMaybe<EvmSubstrateAccountLinkWhereInput>;
+  linkedSubstrateAccounts_some?: InputMaybe<EvmSubstrateAccountLinkWhereInput>;
+};
+
+export type EvmAccountsConnection = {
+  __typename?: 'EvmAccountsConnection';
+  edges: Array<EvmAccountEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+/** The junction table for Many-to-Many relationship between Substrate Account and Ethereum Account */
+export type EvmSubstrateAccountLink = {
+  __typename?: 'EvmSubstrateAccountLink';
+  active: Scalars['Boolean']['output'];
+  /** The block height when a Space was created. */
+  createdAtBlock?: Maybe<Scalars['BigInt']['output']>;
+  /** The DateTime when a Space was created. */
+  createdAtTime?: Maybe<Scalars['DateTime']['output']>;
+  evmAccount: EvmAccount;
+  id: Scalars['String']['output'];
+  substrateAccount: Account;
+};
+
+export type EvmSubstrateAccountLinkEdge = {
+  __typename?: 'EvmSubstrateAccountLinkEdge';
+  cursor: Scalars['String']['output'];
+  node: EvmSubstrateAccountLink;
+};
+
+export enum EvmSubstrateAccountLinkOrderByInput {
+  ActiveAsc = 'active_ASC',
+  ActiveDesc = 'active_DESC',
+  CreatedAtBlockAsc = 'createdAtBlock_ASC',
+  CreatedAtBlockDesc = 'createdAtBlock_DESC',
+  CreatedAtTimeAsc = 'createdAtTime_ASC',
+  CreatedAtTimeDesc = 'createdAtTime_DESC',
+  EvmAccountIdAsc = 'evmAccount_id_ASC',
+  EvmAccountIdDesc = 'evmAccount_id_DESC',
+  IdAsc = 'id_ASC',
+  IdDesc = 'id_DESC',
+  SubstrateAccountFollowersCountAsc = 'substrateAccount_followersCount_ASC',
+  SubstrateAccountFollowersCountDesc = 'substrateAccount_followersCount_DESC',
+  SubstrateAccountFollowingAccountsCountAsc = 'substrateAccount_followingAccountsCount_ASC',
+  SubstrateAccountFollowingAccountsCountDesc = 'substrateAccount_followingAccountsCount_DESC',
+  SubstrateAccountFollowingPostsCountAsc = 'substrateAccount_followingPostsCount_ASC',
+  SubstrateAccountFollowingPostsCountDesc = 'substrateAccount_followingPostsCount_DESC',
+  SubstrateAccountFollowingSpacesCountAsc = 'substrateAccount_followingSpacesCount_ASC',
+  SubstrateAccountFollowingSpacesCountDesc = 'substrateAccount_followingSpacesCount_DESC',
+  SubstrateAccountIdAsc = 'substrateAccount_id_ASC',
+  SubstrateAccountIdDesc = 'substrateAccount_id_DESC',
+  SubstrateAccountOwnedPostsCountAsc = 'substrateAccount_ownedPostsCount_ASC',
+  SubstrateAccountOwnedPostsCountDesc = 'substrateAccount_ownedPostsCount_DESC',
+  SubstrateAccountUpdatedAtBlockAsc = 'substrateAccount_updatedAtBlock_ASC',
+  SubstrateAccountUpdatedAtBlockDesc = 'substrateAccount_updatedAtBlock_DESC',
+  SubstrateAccountUpdatedAtTimeAsc = 'substrateAccount_updatedAtTime_ASC',
+  SubstrateAccountUpdatedAtTimeDesc = 'substrateAccount_updatedAtTime_DESC'
+}
+
+export type EvmSubstrateAccountLinkWhereInput = {
+  AND?: InputMaybe<Array<EvmSubstrateAccountLinkWhereInput>>;
+  OR?: InputMaybe<Array<EvmSubstrateAccountLinkWhereInput>>;
+  active_eq?: InputMaybe<Scalars['Boolean']['input']>;
+  active_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  active_not_eq?: InputMaybe<Scalars['Boolean']['input']>;
+  createdAtBlock_eq?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAtBlock_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAtBlock_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAtBlock_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  createdAtBlock_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  createdAtBlock_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAtBlock_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAtBlock_not_eq?: InputMaybe<Scalars['BigInt']['input']>;
+  createdAtBlock_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  createdAtTime_eq?: InputMaybe<Scalars['DateTime']['input']>;
+  createdAtTime_gt?: InputMaybe<Scalars['DateTime']['input']>;
+  createdAtTime_gte?: InputMaybe<Scalars['DateTime']['input']>;
+  createdAtTime_in?: InputMaybe<Array<Scalars['DateTime']['input']>>;
+  createdAtTime_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  createdAtTime_lt?: InputMaybe<Scalars['DateTime']['input']>;
+  createdAtTime_lte?: InputMaybe<Scalars['DateTime']['input']>;
+  createdAtTime_not_eq?: InputMaybe<Scalars['DateTime']['input']>;
+  createdAtTime_not_in?: InputMaybe<Array<Scalars['DateTime']['input']>>;
+  evmAccount?: InputMaybe<EvmAccountWhereInput>;
+  evmAccount_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  id_contains?: InputMaybe<Scalars['String']['input']>;
+  id_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  id_endsWith?: InputMaybe<Scalars['String']['input']>;
+  id_eq?: InputMaybe<Scalars['String']['input']>;
+  id_gt?: InputMaybe<Scalars['String']['input']>;
+  id_gte?: InputMaybe<Scalars['String']['input']>;
+  id_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  id_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+  id_lt?: InputMaybe<Scalars['String']['input']>;
+  id_lte?: InputMaybe<Scalars['String']['input']>;
+  id_not_contains?: InputMaybe<Scalars['String']['input']>;
+  id_not_containsInsensitive?: InputMaybe<Scalars['String']['input']>;
+  id_not_endsWith?: InputMaybe<Scalars['String']['input']>;
+  id_not_eq?: InputMaybe<Scalars['String']['input']>;
+  id_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  id_not_startsWith?: InputMaybe<Scalars['String']['input']>;
+  id_startsWith?: InputMaybe<Scalars['String']['input']>;
+  substrateAccount?: InputMaybe<AccountWhereInput>;
+  substrateAccount_isNull?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type EvmSubstrateAccountLinksConnection = {
+  __typename?: 'EvmSubstrateAccountLinksConnection';
+  edges: Array<EvmSubstrateAccountLinkEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type HitItem = {
   __typename?: 'HitItem';
@@ -1454,6 +2010,8 @@ export type Post = {
   downvotesCount: Scalars['Int']['output'];
   /** The properties of a Post from its IPFS content which are not supported by the current squid's DB schema. */
   experimental?: Maybe<Scalars['JSON']['output']>;
+  /** The extensions published with this Post. */
+  extensions: Array<ContentExtension>;
   /** The total number of followers that a Post has. */
   followersCount: Scalars['Int']['output'];
   /** The Post format (IPFS content) */
@@ -1528,6 +2086,15 @@ export type PostCommentFollowersArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Array<CommentFollowersOrderByInput>>;
   where?: InputMaybe<CommentFollowersWhereInput>;
+};
+
+
+/** The Post entity */
+export type PostExtensionsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Array<ContentExtensionOrderByInput>>;
+  where?: InputMaybe<ContentExtensionWhereInput>;
 };
 
 
@@ -2133,6 +2700,9 @@ export type PostWhereInput = {
   experimental_jsonContains?: InputMaybe<Scalars['JSON']['input']>;
   experimental_jsonHasKey?: InputMaybe<Scalars['JSON']['input']>;
   experimental_not_eq?: InputMaybe<Scalars['JSON']['input']>;
+  extensions_every?: InputMaybe<ContentExtensionWhereInput>;
+  extensions_none?: InputMaybe<ContentExtensionWhereInput>;
+  extensions_some?: InputMaybe<ContentExtensionWhereInput>;
   followersCount_eq?: InputMaybe<Scalars['Int']['input']>;
   followersCount_gt?: InputMaybe<Scalars['Int']['input']>;
   followersCount_gte?: InputMaybe<Scalars['Int']['input']>;
@@ -2447,6 +3017,21 @@ export type Query = {
   /** @deprecated Use commentFollowersById */
   commentFollowersByUniqueInput?: Maybe<CommentFollowers>;
   commentFollowersConnection: CommentFollowersConnection;
+  contentExtensionById?: Maybe<ContentExtension>;
+  /** @deprecated Use contentExtensionById */
+  contentExtensionByUniqueInput?: Maybe<ContentExtension>;
+  contentExtensions: Array<ContentExtension>;
+  contentExtensionsConnection: ContentExtensionsConnection;
+  evmAccountById?: Maybe<EvmAccount>;
+  /** @deprecated Use evmAccountById */
+  evmAccountByUniqueInput?: Maybe<EvmAccount>;
+  evmAccounts: Array<EvmAccount>;
+  evmAccountsConnection: EvmAccountsConnection;
+  evmSubstrateAccountLinkById?: Maybe<EvmSubstrateAccountLink>;
+  /** @deprecated Use evmSubstrateAccountLinkById */
+  evmSubstrateAccountLinkByUniqueInput?: Maybe<EvmSubstrateAccountLink>;
+  evmSubstrateAccountLinks: Array<EvmSubstrateAccountLink>;
+  evmSubstrateAccountLinksConnection: EvmSubstrateAccountLinksConnection;
   ipfsFetchLogById?: Maybe<IpfsFetchLog>;
   /** @deprecated Use ipfsFetchLogById */
   ipfsFetchLogByUniqueInput?: Maybe<IpfsFetchLog>;
@@ -2593,6 +3178,84 @@ export type QueryCommentFollowersConnectionArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   orderBy: Array<CommentFollowersOrderByInput>;
   where?: InputMaybe<CommentFollowersWhereInput>;
+};
+
+
+export type QueryContentExtensionByIdArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type QueryContentExtensionByUniqueInputArgs = {
+  where: WhereIdInput;
+};
+
+
+export type QueryContentExtensionsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Array<ContentExtensionOrderByInput>>;
+  where?: InputMaybe<ContentExtensionWhereInput>;
+};
+
+
+export type QueryContentExtensionsConnectionArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy: Array<ContentExtensionOrderByInput>;
+  where?: InputMaybe<ContentExtensionWhereInput>;
+};
+
+
+export type QueryEvmAccountByIdArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type QueryEvmAccountByUniqueInputArgs = {
+  where: WhereIdInput;
+};
+
+
+export type QueryEvmAccountsArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Array<EvmAccountOrderByInput>>;
+  where?: InputMaybe<EvmAccountWhereInput>;
+};
+
+
+export type QueryEvmAccountsConnectionArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy: Array<EvmAccountOrderByInput>;
+  where?: InputMaybe<EvmAccountWhereInput>;
+};
+
+
+export type QueryEvmSubstrateAccountLinkByIdArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+export type QueryEvmSubstrateAccountLinkByUniqueInputArgs = {
+  where: WhereIdInput;
+};
+
+
+export type QueryEvmSubstrateAccountLinksArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Array<EvmSubstrateAccountLinkOrderByInput>>;
+  where?: InputMaybe<EvmSubstrateAccountLinkWhereInput>;
+};
+
+
+export type QueryEvmSubstrateAccountLinksConnectionArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy: Array<EvmSubstrateAccountLinkOrderByInput>;
+  where?: InputMaybe<EvmSubstrateAccountLinkWhereInput>;
 };
 
 
@@ -4242,14 +4905,21 @@ export type WhereIdInput = {
 };
 
 export type GetPostsQueryVariables = Exact<{
-  ids?: Maybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
+  ids?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
 }>;
 
 
 export type GetPostsQuery = { __typename?: 'Query', posts: Array<{ __typename?: 'Post', content?: string | null, createdAtBlock?: any | null, createdAtTime?: any | null, title?: string | null, body?: string | null, summary?: string | null, isShowMore?: boolean | null, image?: string | null, link?: string | null, downvotesCount: number, hidden: boolean, id: string, isComment: boolean, kind?: PostKind | null, repliesCount: number, sharesCount: number, upvotesCount: number, updatedAtTime?: any | null, canonical?: string | null, tagsOriginal?: string | null, tweetId?: string | null, createdByAccount: { __typename?: 'Account', id: string }, tweetDetails?: { __typename?: 'TweetDetails', username?: string | null } | null, ownedByAccount: { __typename?: 'Account', id: string }, space?: { __typename?: 'Space', id: string } | null, rootPost?: { __typename?: 'Post', id: string } | null, sharedPost?: { __typename?: 'Post', id: string } | null }> };
 
+export type GetPostsByContentQueryVariables = Exact<{
+  search: Scalars['String']['input'];
+}>;
+
+
+export type GetPostsByContentQuery = { __typename?: 'Query', posts: Array<{ __typename?: 'Post', content?: string | null, createdAtBlock?: any | null, createdAtTime?: any | null, title?: string | null, body?: string | null, summary?: string | null, isShowMore?: boolean | null, image?: string | null, link?: string | null, downvotesCount: number, hidden: boolean, id: string, isComment: boolean, kind?: PostKind | null, repliesCount: number, sharesCount: number, upvotesCount: number, updatedAtTime?: any | null, canonical?: string | null, tagsOriginal?: string | null, tweetId?: string | null, createdByAccount: { __typename?: 'Account', id: string }, tweetDetails?: { __typename?: 'TweetDetails', username?: string | null } | null, ownedByAccount: { __typename?: 'Account', id: string }, space?: { __typename?: 'Space', id: string } | null, rootPost?: { __typename?: 'Post', id: string } | null, sharedPost?: { __typename?: 'Post', id: string } | null }> };
+
 export type GetSpacesQueryVariables = Exact<{
-  ids?: Maybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
+  ids?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
 }>;
 
 
@@ -4332,6 +5002,15 @@ export const PostFragment = gql`
 export const GetPosts = gql`
     query getPosts($ids: [String!]) {
   posts(where: {id_in: $ids, hidden_eq: false}) {
+    ...PostFragment
+  }
+}
+    ${PostFragment}`;
+export const GetPostsByContent = gql`
+    query getPostsByContent($search: String!) {
+  posts(
+    where: {hidden_eq: false, title_containsInsensitive: $search, OR: {body_containsInsensitive: $search}}
+  ) {
     ...PostFragment
   }
 }

--- a/src/services/subsocial/squid/generated.ts
+++ b/src/services/subsocial/squid/generated.ts
@@ -4914,6 +4914,7 @@ export type GetPostsQuery = { __typename?: 'Query', posts: Array<{ __typename?: 
 export type GetPostsByContentQueryVariables = Exact<{
   search: Scalars['String']['input'];
   spaceIds: Array<Scalars['String']['input']> | Scalars['String']['input'];
+  postIds: Array<Scalars['String']['input']> | Scalars['String']['input'];
 }>;
 
 
@@ -5008,7 +5009,7 @@ export const GetPosts = gql`
 }
     ${PostFragment}`;
 export const GetPostsByContent = gql`
-    query getPostsByContent($search: String!, $spaceIds: [String!]!) {
+    query getPostsByContent($search: String!, $spaceIds: [String!]!, $postIds: [String!]!) {
   posts(
     where: {hidden_eq: false, isComment_eq: false, title_containsInsensitive: $search, space: {id_in: $spaceIds}}
   ) {

--- a/src/services/subsocial/squid/generated.ts
+++ b/src/services/subsocial/squid/generated.ts
@@ -4913,6 +4913,7 @@ export type GetPostsQuery = { __typename?: 'Query', posts: Array<{ __typename?: 
 
 export type GetPostsByContentQueryVariables = Exact<{
   search: Scalars['String']['input'];
+  spaceIds: Array<Scalars['String']['input']> | Scalars['String']['input'];
 }>;
 
 
@@ -5007,9 +5008,9 @@ export const GetPosts = gql`
 }
     ${PostFragment}`;
 export const GetPostsByContent = gql`
-    query getPostsByContent($search: String!) {
+    query getPostsByContent($search: String!, $spaceIds: [String!]!) {
   posts(
-    where: {hidden_eq: false, title_containsInsensitive: $search, OR: {body_containsInsensitive: $search}}
+    where: {hidden_eq: false, isComment_eq: false, title_containsInsensitive: $search, space: {id_in: $spaceIds}}
   ) {
     ...PostFragment
   }

--- a/src/services/subsocial/squid/mappers.ts
+++ b/src/services/subsocial/squid/mappers.ts
@@ -1,4 +1,4 @@
-import { PostData, SpaceData } from '@subsocial/api/types'
+import { CommentStruct, PostData, SpaceData } from '@subsocial/api/types'
 import { PostFragmentFragment, SpaceFragmentFragment } from './generated'
 
 const SQUID_SEPARATOR = ','
@@ -35,26 +35,29 @@ export const mapSpaceFragment = (space: SpaceFragmentFragment): SpaceData => {
 }
 
 export const mapPostFragment = (post: PostFragmentFragment): PostData => {
+  const struct: CommentStruct = {
+    createdAtBlock: parseInt(post.createdAtBlock),
+    createdAtTime: new Date(post.createdAtTime).getTime(),
+    createdByAccount: post.createdByAccount.id,
+    downvotesCount: post.downvotesCount,
+    hidden: post.hidden,
+    id: post.id,
+    isComment: post.isComment,
+    isRegularPost: post.kind === 'RegularPost',
+    isSharedPost: post.kind === 'SharedPost',
+    ownerId: post.ownedByAccount.id,
+    upvotesCount: post.upvotesCount,
+    contentId: post.content ?? '',
+    repliesCount: post.repliesCount,
+    sharesCount: post.sharesCount,
+    spaceId: post.space?.id ?? '',
+    isUpdated: !!post.updatedAtTime,
+    rootPostId: post.rootPost?.id ?? '',
+  }
+
   return {
     id: post.id,
-    struct: {
-      createdAtBlock: parseInt(post.createdAtBlock),
-      createdAtTime: new Date(post.createdAtTime).getTime(),
-      createdByAccount: post.createdByAccount.id,
-      downvotesCount: post.downvotesCount,
-      hidden: post.hidden,
-      id: post.id,
-      isComment: post.isComment,
-      isRegularPost: post.kind === 'RegularPost',
-      isSharedPost: post.kind === 'SharedPost',
-      ownerId: post.ownedByAccount.id,
-      upvotesCount: post.upvotesCount,
-      contentId: post.content ?? '',
-      repliesCount: post.repliesCount,
-      sharesCount: post.sharesCount,
-      spaceId: post.space?.id ?? '',
-      isUpdated: !!post.updatedAtTime,
-    },
+    struct,
     content: {
       summary: post.summary ?? '',
       image: post.image ?? '',

--- a/src/services/subsocial/squid/utils.ts
+++ b/src/services/subsocial/squid/utils.ts
@@ -4,5 +4,8 @@ import request, { RequestOptions, Variables } from 'graphql-request'
 export function squidRequest<T, V extends Variables = Variables>(
   config: RequestOptions<V, T>
 ) {
-  return request({ url: getSquidUrl(), ...config })
+  const url = getSquidUrl()
+  if (!url) throw new Error('Squid URL is not defined')
+
+  return request({ url, ...config })
 }

--- a/src/subsocial-query/base.ts
+++ b/src/subsocial-query/base.ts
@@ -93,9 +93,15 @@ export function createQuery<Data, ReturnValue>({
 }) {
   const getQueryKey = createQueryKeys<Data>(key)
 
-  async function fetchQuery(client: QueryClient, data: Data) {
+  async function fetchQuery(client: QueryClient | null, data: Data) {
+    const cachedData = client?.getQueryData(getQueryKey(data))
+    if (cachedData) {
+      return cachedData as ReturnValue
+    }
+
     const res = await fetcher(data)
-    client.setQueryData(getQueryKey(data), res ?? null)
+    if (client) client.setQueryData(getQueryKey(data), res ?? null)
+
     return res
   }
 

--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -1,5 +1,20 @@
+import { CID } from 'ipfs-http-client'
+
+enum CID_KIND {
+  CBOR = 113,
+  UNIXFS = 112,
+}
+
 export function getIpfsContentUrl(cid: string) {
   if (!cid || cid.startsWith('http')) return cid
+
+  const ipfsCid = CID.parse(cid)
+  if (!ipfsCid) return cid
+
+  const isCbor = ipfsCid.code === CID_KIND.CBOR
+  if (isCbor) {
+    return `https://ipfs.subsocial.network/api/v0/dag/get?arg=${cid}`
+  }
   return `https://ipfs.subsocial.network/ipfs/${cid}`
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3279,7 +3279,7 @@
     "@stablelib/random" "^1.0.2"
     "@stablelib/wipe" "^1.0.1"
 
-"@subsocial/api@^0.8.10":
+"@subsocial/api@^0.8.12":
   version "0.8.13"
   resolved "https://registry.yarnpkg.com/@subsocial/api/-/api-0.8.13.tgz#94f69c8d870419d2becc346fd1202e36b8c066f6"
   integrity sha512-jnbHm4bblYeYAYnriQDS9ehigGektPhwtxsHieXP+rYMKl3tu5ebbCOyCu/HXNavlEGFVGQmW1tYqw2VKhIC7w==


### PR DESCRIPTION
# Changes
- Change flow of `useSearch` and create `SearchChannelsWrapper` for managing global/local search
- Create `getPostsByContent` query
- If squid env is not provided, the global search will change its behavior to just local search using `main space id` posts