### PR TITLE
Add parser for different kind of cid

### DIFF
--- a/src/utils/ipfs.ts
+++ b/src/utils/ipfs.ts
@@ -1,5 +1,20 @@
+import { CID } from 'ipfs-http-client'
+
+enum CID_KIND {
+  CBOR = 113,
+  UNIXFS = 112,
+}
+
 export function getIpfsContentUrl(cid: string) {
   if (!cid || cid.startsWith('http')) return cid
+
+  const ipfsCid = CID.parse(cid)
+  if (!ipfsCid) return cid
+
+  const isCbor = ipfsCid.code === CID_KIND.CBOR
+  if (isCbor) {
+    return `https://ipfs.subsocial.network/api/v0/dag/get?arg=${cid}`
+  }
   return `https://ipfs.subsocial.network/ipfs/${cid}`
 }
 


### PR DESCRIPTION
# Issue
Currently, the cid link is resolved only with single url `https://ipfs.subsocial.network/ipfs/${cid}`.
But some cids need to use different url like `https://ipfs.subsocial.network/api/v0/dag/get?arg=${cid}`

To solve this, added validation for the ipfs resolver

# Note
I didn't use `asIpfsCid` from `@subsocial/api` because importing just that will result in increase >500kb for bundle size, while importing just `ipfs-http-client` increases ~50kb bundle size