### PR TITLE
Fix duplicate fetching and add result param for get space

### DIFF
--- a/src/services/subsocial/spaces/query.ts
+++ b/src/services/subsocial/spaces/query.ts
@@ -42,6 +42,10 @@ const getSpaceFromSquid = poolQuery<string, SpaceData>({
     })
     return res.spaces.map((space) => mapSpaceFragment(space))
   },
+  resultMapper: {
+    paramToKey: (param) => param,
+    resultToKey: (result) => result?.id ?? '',
+  },
 })
 
 export const getSpaceQuery = createDynamicSubsocialQuery('getSpace', {

--- a/src/subsocial-query/base.ts
+++ b/src/subsocial-query/base.ts
@@ -93,9 +93,15 @@ export function createQuery<Data, ReturnValue>({
 }) {
   const getQueryKey = createQueryKeys<Data>(key)
 
-  async function fetchQuery(client: QueryClient, data: Data) {
+  async function fetchQuery(client: QueryClient | null, data: Data) {
+    const cachedData = client?.getQueryData(getQueryKey(data))
+    if (cachedData) {
+      return cachedData as ReturnValue
+    }
+
     const res = await fetcher(data)
-    client.setQueryData(getQueryKey(data), res ?? null)
+    if (client) client.setQueryData(getQueryKey(data), res ?? null)
+
     return res
   }
 


### PR DESCRIPTION
# Issue
Because there is no result mapper for the get space, the order was broken because squid doesn't return the spaces in order.
Other than that, because the main space id was fetched twice, there was duplicate data, which makes there are duplicate keys making the hubs behave weirdly. 

# Solution
Add cache checker for fetchQuery to prevent unnecessary fetching, and add result mapper for get space