### PR TITLE
Fix issue where message from squid won't be recognized as the owner's

### DIFF
--- a/src/components/auth/ProfileModal/contents/LinkEvmAddressContent.tsx
+++ b/src/components/auth/ProfileModal/contents/LinkEvmAddressContent.tsx
@@ -12,12 +12,12 @@ import { ContentProps } from '../types'
 function LinkEvmAddressContent({ evmAddress, setCurrentState }: ContentProps) {
   const { address: addressFromExt } = useAccount()
 
-  const addressFromExtLovercased = addressFromExt?.toLowerCase()
+  const addressFromExtLowercased = addressFromExt?.toLowerCase()
 
   const isNotEqAddresses =
-    !!addressFromExtLovercased &&
+    !!addressFromExtLowercased &&
     !!evmAddress &&
-    evmAddress !== addressFromExtLovercased
+    evmAddress !== addressFromExtLowercased
 
   const { signAndLinkEvmAddress, isLoading } = useSignMessageAndLinkEvmAddress({
     setModalStep: () => setCurrentState('evm-address-linked'),

--- a/src/pages/api/posts.ts
+++ b/src/pages/api/posts.ts
@@ -1,5 +1,6 @@
 import { getPostsFromSubsocial } from '@/services/subsocial/posts/fetcher'
 import { PostData } from '@subsocial/api/types'
+import { toSubsocialAddress } from '@subsocial/utils'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { z } from 'zod'
 
@@ -49,6 +50,10 @@ export async function getPostsServer(postIds: string[]): Promise<PostData[]> {
     notFoundPostIds,
     'blockchain'
   )
+
+  postsFromBlockchain.forEach((post) => {
+    post.struct.ownerId = toSubsocialAddress(post.struct.ownerId)!
+  })
 
   return [...posts, ...postsFromBlockchain].filter((post) => !!post)
 }

--- a/src/services/subsocial/evmAddresses/mutation.tsx
+++ b/src/services/subsocial/evmAddresses/mutation.tsx
@@ -65,7 +65,7 @@ export function useLinkEvmAddress({
         onStart: () => setOnCallbackLoading(true),
         onSuccess: async ({ address }) => {
           await mutateAccountsDataCache(address)
-          await getAccountDataQuery.fetchQuery(client, address)
+          getAccountDataQuery.invalidate(client, address)
 
           setOnCallbackLoading(false)
           setModalStep?.()

--- a/src/stores/my-account.ts
+++ b/src/stores/my-account.ts
@@ -67,13 +67,15 @@ const currentSessionStorage = new LocalStorage(() => SESSION_STORAGE_KEY)
 export const useMyAccount = create<State & Actions>()((set, get) => ({
   ...initialState,
   login: async (secretKey, isInitialization) => {
+    const { toSubsocialAddress } = await import('@subsocial/utils')
     const { _syncSessionKey, _getSecretKeyForLogin } = get()
     let address: string = ''
     try {
       secretKey = secretKey || (await _getSecretKeyForLogin())
       const signer = await loginWithSecretKey(secretKey)
       const encodedSecretKey = encodeSecretKey(secretKey)
-      address = signer.address
+      address = toSubsocialAddress(signer.address)!
+
       set({
         address,
         signer,


### PR DESCRIPTION
# Issue
- Before, blockchain returns address with prefix 32, now from squid, it returns with subsocial prefix, so the messages that comes from squid won't be recognized with the owner

- After linking evm account, the evm address is not reloaded, making user don't have the evm linked account shown in their profile