### PR TITLE
Add squid timeout

### DIFF
--- a/src/services/subsocial/squid/utils.ts
+++ b/src/services/subsocial/squid/utils.ts
@@ -7,8 +7,9 @@ export function squidRequest<T, V extends Variables = Variables>(
   const url = getSquidUrl()
   if (!url) throw new Error('Squid URL is not defined')
 
+  const SQUID_TIMEOUT = 3 * 1000 // 3 seconds
   const client = new GraphQLClient(url, {
-    timeout: 1000,
+    timeout: SQUID_TIMEOUT,
     ...config,
   })
 

--- a/src/services/subsocial/squid/utils.ts
+++ b/src/services/subsocial/squid/utils.ts
@@ -1,8 +1,16 @@
 import { getSquidUrl } from '@/utils/env/client'
-import request, { RequestOptions, Variables } from 'graphql-request'
+import { GraphQLClient, RequestOptions, Variables } from 'graphql-request'
 
 export function squidRequest<T, V extends Variables = Variables>(
   config: RequestOptions<V, T>
 ) {
-  return request({ url: getSquidUrl(), ...config })
+  const url = getSquidUrl()
+  if (!url) throw new Error('Squid URL is not defined')
+
+  const client = new GraphQLClient(url, {
+    timeout: 1000,
+    ...config,
+  })
+
+  return client.request({ url, ...config })
 }


### PR DESCRIPTION
Add squid timeout, especially for posts, so if squid is down, it won't just loading infinitely.

This will help in cases where the squid is broken after build is done, so the client can still get posts data correctly from the /api/posts