### PR TITLE
Remove withEnsAvatar Flag

### DIFF
--- a/src/components/AddressAvatar.tsx
+++ b/src/components/AddressAvatar.tsx
@@ -16,13 +16,13 @@ export type AddressAvatarProps = ComponentProps<'div'> & {
 const AddressAvatar = forwardRef<HTMLDivElement, AddressAvatarProps>(
   function AddressAvatar({ address, ...props }: AddressAvatarProps, ref) {
     const backgroundColor = useRandomColor(address, 'dark')
-    const [ensAvatarLoading, setEnsAvatarLoading] = useState(true)
-    const [isLoadingError, setIsLoadingError] = useState(false)
+
+    const [ensAvatarLoaded, setEnsAvatarLoaded] = useState(false)
 
     const { data: accountData, isLoading } =
       getAccountDataQuery.useQuery(address)
 
-    const { ensName, withEnsAvatar } = accountData || {}
+    const { ensName } = accountData || {}
 
     const avatar = useMemo(() => {
       return createAvatar(bottts, {
@@ -31,7 +31,7 @@ const AddressAvatar = forwardRef<HTMLDivElement, AddressAvatarProps>(
       }).toDataUriSync()
     }, [address])
 
-    if (!accountData && isLoading && ensAvatarLoading) {
+    if (isLoading) {
       return (
         <div
           className={cx(
@@ -50,11 +50,6 @@ const AddressAvatar = forwardRef<HTMLDivElement, AddressAvatarProps>(
       )
     }
 
-    const avatarSrc =
-      withEnsAvatar && ensName && !isLoadingError
-        ? resolveEnsAvatarSrc(ensName)
-        : avatar
-
     return (
       <div
         {...props}
@@ -65,19 +60,33 @@ const AddressAvatar = forwardRef<HTMLDivElement, AddressAvatarProps>(
         )}
         style={{ backgroundColor }}
       >
-        <div
-          className={cx('relative h-full w-full', {
-            ['p-[7.5%]']: !withEnsAvatar,
-          })}
-        >
+        {ensName && (
+          <div
+            className={cx(
+              'absolute inset-0 h-full w-full transition-opacity',
+              ensAvatarLoaded ? 'z-10 opacity-100' : '-z-10 opacity-0'
+            )}
+          >
+            <div className='relative h-full w-full'>
+              <Image
+                sizes='5rem'
+                className='relative'
+                fill
+                src={resolveEnsAvatarSrc(ensName)}
+                onLoad={() => setEnsAvatarLoaded(true)}
+                alt='avatar'
+              />
+            </div>
+          </div>
+        )}
+
+        <div className={cx('relative h-full w-full p-[7.5%]')}>
           <div className='relative h-full w-full'>
             <Image
               sizes='5rem'
               className='relative'
               fill
-              src={avatarSrc}
-              onLoad={() => setEnsAvatarLoading(false)}
-              onError={() => setIsLoadingError(true)}
+              src={avatar}
               alt='avatar'
             />
           </div>

--- a/src/components/chats/ChatForm.tsx
+++ b/src/components/chats/ChatForm.tsx
@@ -133,11 +133,7 @@ export default function ChatForm({
     clearReplyTo?.()
   }
 
-  const handleSubmit = async (
-    captchaToken: string | null,
-    e?: SyntheticEvent
-  ) => {
-    e?.preventDefault()
+  const handleSubmit = async (captchaToken: string | null) => {
     if (
       shouldSendMessage &&
       'virtualKeyboard' in navigator &&
@@ -192,12 +188,13 @@ export default function ChatForm({
       <CaptchaInvisible>
         {(runCaptcha) => {
           const submitForm = async (e?: SyntheticEvent) => {
+            e?.preventDefault()
             if (shouldSendMessage) {
-              handleSubmit(null, e)
+              handleSubmit(null)
               return
             }
             const token = await runCaptcha()
-            handleSubmit(token, e)
+            handleSubmit(token)
           }
 
           const renderSendButton = (classNames: string) => (
@@ -205,8 +202,7 @@ export default function ChatForm({
               onTouchEnd={(e) => {
                 // For mobile, to prevent keyboard from hiding
                 if (shouldSendMessage) {
-                  e.preventDefault()
-                  submitForm()
+                  submitForm(e)
                 }
               }}
               tabIndex={-1}

--- a/src/pages/api/accounts-data.ts
+++ b/src/pages/api/accounts-data.ts
@@ -1,7 +1,5 @@
-import { resolveEnsAvatarSrc } from '@/components/AddressAvatar'
 import { redisCallWrapper } from '@/server/cache'
 import { getSubsocialApi } from '@/subsocial-query/subsocial/connection'
-import axios from 'axios'
 import { request } from 'graphql-request'
 import gql from 'graphql-tag'
 
@@ -12,7 +10,6 @@ export type AccountData = {
   grillAddress: string
   evmAddress: string
   ensName: string | null
-  withEnsAvatar: boolean
 }
 
 const querySchema = z.object({
@@ -83,17 +80,6 @@ function invalidateCache(addresses: string[]) {
   })
 }
 
-async function checkEnsAvatar(ensName: string | null) {
-  if (!ensName) return false
-
-  try {
-    const result = await axios.get(resolveEnsAvatarSrc(ensName))
-    return !result.data?.message
-  } catch {
-    return false
-  }
-}
-
 type Domain = {
   name: string
   resolvedAddress: { id: string }
@@ -145,7 +131,6 @@ async function fetchAccountsData(addresses: string[]) {
         grillAddress: address,
         evmAddress: evmAddressesHuman[i],
         ensName,
-        withEnsAvatar: await checkEnsAvatar(ensName),
       }
 
       newlyFetchedData.push(accountData)


### PR DESCRIPTION
# Issue
Currently, if you at one time fetch an image and maybe the server is down or something, and the `withEnsAvatar` becomes false, it will get cached for 1 hour, so that account won't have image for that duration

# Solution
Remove `withEnsAvatar` flag, instead just always try to get the image in frontend side. Show the default avatar if its loading, and after its loaded, put the ens image in front.