### PR TITLE
Optimize moderation queries and react query hydration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,7 @@ const nextConfig = {
   reactStrictMode: true,
   experimental: {
     scrollRestoration: true,
+    largePageDataBytes: 200 * 1024, // 200kb
   },
 
   webpack(config) {

--- a/src/components/chats/ChatPreviewList.tsx
+++ b/src/components/chats/ChatPreviewList.tsx
@@ -8,7 +8,7 @@ import { PostData } from '@subsocial/api/types'
 import { useRouter } from 'next/router'
 import { ComponentProps } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
-import ChatPreview from './ChatPreview/ChatPreview'
+import ChatPreview from './ChatPreview'
 
 export type ChatPreviewListProps = ComponentProps<'div'> & {
   chats: (PostData | undefined | null)[]

--- a/src/components/extensions/config.ts
+++ b/src/components/extensions/config.ts
@@ -1,19 +1,31 @@
 import { useExtensionData } from '@/stores/extension'
 import { getUrlFromText } from '@/utils/strings'
 import { PostContentExtension } from '@subsocial/api/types'
-import { ClipboardEvent } from 'react'
-import DonateMessagePreview from './donate/DonateMessagePreview'
-import DonateRepliedMessagePreviewPart from './donate/DonateRepliedMessagePreviewPart'
-import ImageChatItem from './image/ImageChatItem'
-import ImageRepliedMessagePreviewPart from './image/ImageRepliedMessagePreviewPart'
+import dynamic from 'next/dynamic'
+import { ClipboardEvent, ComponentType } from 'react'
 import { SUPPORTED_IMAGE_EXTENSIONS } from './image/utils'
-import NftChatItem from './nft/NftChatItem'
-import NftRepliedMessagePreviewPart from './nft/NftRepliedMessagePreviewPart'
 import { parseNftMarketplaceLink } from './nft/utils'
 import {
   ExtensionChatItemProps,
   RepliedMessagePreviewPartsProps,
 } from './types'
+
+const DonateMessagePreview = dynamic(
+  () => import('./donate/DonateMessagePreview')
+)
+const DonateRepliedMessagePreviewPart = dynamic(
+  () => import('./donate/DonateRepliedMessagePreviewPart')
+)
+
+const ImageChatItem = dynamic(() => import('./image/ImageChatItem'))
+const ImageRepliedMessagePreviewPart = dynamic(
+  () => import('./image/ImageRepliedMessagePreviewPart')
+)
+
+const NftChatItem = dynamic(() => import('./nft/NftChatItem'))
+const NftRepliedMessagePreviewPart = dynamic(
+  () => import('./nft/NftRepliedMessagePreviewPart')
+)
 
 export const extensionInitialDataTypes = {
   'subsocial-donations': { recipient: '', messageId: '' },
@@ -22,7 +34,7 @@ export const extensionInitialDataTypes = {
 } satisfies Record<PostContentExtension['id'], unknown>
 
 type Config<Id extends PostContentExtension['id']> = {
-  chatItemComponent: (props: ExtensionChatItemProps) => JSX.Element | null
+  chatItemComponent: ComponentType<ExtensionChatItemProps>
   replyMessageUI: RepliedMessagePreviewPartsProps
   pasteInterception?: (
     clipboardData: DataTransfer,

--- a/src/components/extensions/index.tsx
+++ b/src/components/extensions/index.tsx
@@ -1,6 +1,14 @@
-import DonateModal from './donate/DonateModal/DonateModal'
-import ImageModal from './image/ImageModal'
-import NftModal from './nft/NftModal'
+import dynamic from 'next/dynamic'
+
+const DonateModal = dynamic(() => import('./donate/DonateModal/DonateModal'), {
+  ssr: false,
+})
+const ImageModal = dynamic(() => import('./image/ImageModal'), {
+  ssr: false,
+})
+const NftModal = dynamic(() => import('./nft/NftModal'), {
+  ssr: false,
+})
 
 export type ExtensionModalsProps = {
   chatId: string

--- a/src/components/extensions/types.ts
+++ b/src/components/extensions/types.ts
@@ -1,5 +1,5 @@
 import { PostContent, PostData } from '@subsocial/api/types'
-import { SyntheticEvent } from 'react'
+import { ComponentType, SyntheticEvent } from 'react'
 
 export type ExtensionChatItemProps = {
   message: PostData
@@ -21,6 +21,6 @@ export type RepliedMessageConfig = {
 }
 
 export type RepliedMessagePreviewPartsProps = {
-  element: (props: RepliedMessagePreviewPartProps) => JSX.Element | null
+  element: ComponentType<RepliedMessagePreviewPartProps>
   config: RepliedMessageConfig
 }

--- a/src/hooks/useFilterBlockedMessageIds.ts
+++ b/src/hooks/useFilterBlockedMessageIds.ts
@@ -7,12 +7,12 @@ export default function useFilterBlockedMessageIds(
   chatId: string,
   messageIds: string[]
 ) {
-  const { data: blockedIds } = getBlockedMessageIdsInChatIdQuery.useQuery({
+  const { data } = getBlockedMessageIdsInChatIdQuery.useQuery({
     hubId,
     chatId,
   })
 
   return useMemo(() => {
-    return filterBlockedMessageIds(messageIds, blockedIds)
-  }, [blockedIds, messageIds])
+    return filterBlockedMessageIds(messageIds, data?.blockedMessageIds)
+  }, [data?.blockedMessageIds, messageIds])
 }

--- a/src/hooks/useIsMessageBlocked.ts
+++ b/src/hooks/useIsMessageBlocked.ts
@@ -12,7 +12,7 @@ export default function useIsMessageBlocked(
   message: PostData | null | undefined,
   chatId: string
 ) {
-  const { data: blockedIds } = getBlockedMessageIdsInChatIdQuery.useQuery({
+  const { data: blockedMessages } = getBlockedMessageIdsInChatIdQuery.useQuery({
     chatId,
     hubId,
   })
@@ -21,7 +21,10 @@ export default function useIsMessageBlocked(
     hubId,
   })
 
-  const blockedIdsSet = useMemo(() => new Set(blockedIds), [blockedIds])
+  const blockedIdsSet = useMemo(
+    () => new Set(blockedMessages?.blockedMessageIds),
+    [blockedMessages]
+  )
   const blockedCidsSet = useMemo(() => new Set(blockedCids), [blockedCids])
   const blockedAddressesSet = useMemo(
     () => new Set(blockedAddresses),

--- a/src/pages/[hubId]/[slug]/index.tsx
+++ b/src/pages/[hubId]/[slug]/index.tsx
@@ -14,10 +14,10 @@ import {
   getPriceQuery,
 } from '@/services/subsocial/prices/query'
 import { getSubsocialApi } from '@/subsocial-query/subsocial/connection'
-import { getCommonStaticProps } from '@/utils/page'
+import { dehydrateQueries, getCommonStaticProps } from '@/utils/page'
 import { getIdFromSlug } from '@/utils/slug'
 import { validateNumber } from '@/utils/strings'
-import { dehydrate, QueryClient } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
 import { GetStaticPaths } from 'next'
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -120,7 +120,7 @@ export const getStaticProps = getCommonStaticProps<
 
     return {
       props: {
-        dehydratedState: dehydrate(queryClient),
+        dehydratedState: dehydrateQueries(queryClient),
         chatId,
         hubId,
         head: {

--- a/src/pages/[hubId]/index.tsx
+++ b/src/pages/[hubId]/index.tsx
@@ -2,9 +2,9 @@ import { getHubIdFromAlias } from '@/constants/hubs'
 import HubPage, { HubPageProps } from '@/modules/chat/HubPage'
 import { prefetchChatPreviewsData } from '@/server/chats'
 import { getMainHubId } from '@/utils/env/client'
-import { getCommonStaticProps } from '@/utils/page'
+import { dehydrateQueries, getCommonStaticProps } from '@/utils/page'
 import { validateNumber } from '@/utils/strings'
-import { dehydrate, QueryClient } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
 import { AppCommonProps } from '../_app'
 
 export const getStaticPaths = async () => {
@@ -48,7 +48,7 @@ export const getStaticProps = getCommonStaticProps<
 
     return {
       props: {
-        dehydratedState: dehydrate(queryClient),
+        dehydratedState: dehydrateQueries(queryClient),
         hubId,
       },
       revalidate: 2,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,7 +15,7 @@ import type { AppProps } from 'next/app'
 import { Source_Sans_Pro } from 'next/font/google'
 import { GoogleAnalytics } from 'nextjs-google-analytics'
 import NextNProgress from 'nextjs-progressbar'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { Toaster } from 'react-hot-toast'
 
 export type AppCommonProps = {
@@ -69,8 +69,9 @@ export default function App(props: AppProps<AppCommonProps>) {
 
 function AppContent({ Component, pageProps }: AppProps<AppCommonProps>) {
   const { head, dehydratedState, ...props } = pageProps
-  const [parsedDehydratedState] = useState(() =>
-    parseDehydratedState(dehydratedState)
+  const parsedDehydratedState = useMemo(
+    () => parseDehydratedState(dehydratedState),
+    [dehydratedState]
   )
 
   const isInitialized = useRef(false)

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,13 +8,14 @@ import { initAllStores } from '@/stores/registry'
 import '@/styles/globals.css'
 import { cx } from '@/utils/class-names'
 import { getGaId } from '@/utils/env/client'
+import { parseDehydratedState } from '@/utils/page'
 import '@rainbow-me/rainbowkit/styles.css'
 import { ThemeProvider } from 'next-themes'
 import type { AppProps } from 'next/app'
 import { Source_Sans_Pro } from 'next/font/google'
 import { GoogleAnalytics } from 'nextjs-google-analytics'
 import NextNProgress from 'nextjs-progressbar'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Toaster } from 'react-hot-toast'
 
 export type AppCommonProps = {
@@ -68,6 +69,10 @@ export default function App(props: AppProps<AppCommonProps>) {
 
 function AppContent({ Component, pageProps }: AppProps<AppCommonProps>) {
   const { head, dehydratedState, ...props } = pageProps
+  const [parsedDehydratedState] = useState(() =>
+    parseDehydratedState(dehydratedState)
+  )
+
   const isInitialized = useRef(false)
   const { theme } = useConfigContext()
 
@@ -86,7 +91,7 @@ function AppContent({ Component, pageProps }: AppProps<AppCommonProps>) {
 
   return (
     <ThemeProvider attribute='class' forcedTheme={theme}>
-      <QueryProvider dehydratedState={dehydratedState}>
+      <QueryProvider dehydratedState={parsedDehydratedState}>
         <ToasterConfig />
         <NextNProgress
           color='#4d46dc'

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,8 +8,8 @@ import { prefetchChatPreviewsData } from '@/server/chats'
 import { getPostIdsBySpaceIdQuery } from '@/services/subsocial/posts'
 import { getSpaceQuery } from '@/services/subsocial/spaces'
 import { getHubIds, getMainHubId } from '@/utils/env/client'
-import { getCommonStaticProps } from '@/utils/page'
-import { dehydrate, QueryClient } from '@tanstack/react-query'
+import { dehydrateQueries, getCommonStaticProps } from '@/utils/page'
+import { QueryClient } from '@tanstack/react-query'
 
 export const getStaticProps = getCommonStaticProps<
   HubsPageProps & AppCommonProps
@@ -46,7 +46,7 @@ export const getStaticProps = getCommonStaticProps<
 
     return {
       props: {
-        dehydratedState: dehydrate(queryClient),
+        dehydratedState: dehydrateQueries(queryClient),
         hubsChatCount,
         isIntegrateChatButtonOnTop: Math.random() > 0.5,
       },

--- a/src/server/notifications/utils.ts
+++ b/src/server/notifications/utils.ts
@@ -7,7 +7,7 @@ export function notificationsRequest<T, V extends Variables = Variables>(
   const { url, token } = getNotificationsConfig()
   if (!url || !token) throw new Error('Notifications config not found')
 
-  const TIMEOUT = 3 * 1000 // 1 seconds
+  const TIMEOUT = 3 * 1000 // 3 seconds
   const client = new GraphQLClient(url, {
     timeout: TIMEOUT,
     headers: {

--- a/src/services/api/query.ts
+++ b/src/services/api/query.ts
@@ -15,7 +15,7 @@ const getPost = poolQuery<string, PostData>({
   },
 })
 export const getPostQuery = createQuery({
-  key: 'getPost',
+  key: 'post',
   fetcher: getPost,
 })
 
@@ -31,6 +31,6 @@ async function getNft(nft: ApiNftParams | null) {
   return responseData.data
 }
 export const getNftQuery = createQuery({
-  key: 'getNft',
+  key: 'nft',
   fetcher: getNft,
 })

--- a/src/services/moderation/generated.ts
+++ b/src/services/moderation/generated.ts
@@ -1,234 +1,203 @@
-import gql from 'graphql-tag'
-export type Maybe<T> = T | null
-export type InputMaybe<T> = Maybe<T>
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K]
-}
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>
-}
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>
-}
-export type MakeEmpty<
-  T extends { [key: string]: unknown },
-  K extends keyof T
-> = { [_ in K]?: never }
-export type Incremental<T> =
-  | T
-  | {
-      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never
-    }
+import gql from 'graphql-tag';
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string | number; output: string }
-  String: { input: string; output: string }
-  Boolean: { input: boolean; output: boolean }
-  Int: { input: number; output: number }
-  Float: { input: number; output: number }
-  DateTime: { input: any; output: any }
-}
+  ID: { input: string | number; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  DateTime: { input: any; output: any; }
+};
 
 export type BlockReasonGql = {
-  __typename?: 'BlockReasonGql'
-  id: Scalars['Float']['output']
-  reasonText: Scalars['String']['output']
-}
+  __typename?: 'BlockReasonGql';
+  id: Scalars['Float']['output'];
+  reasonText: Scalars['String']['output'];
+};
 
 export type BlockReasonGqlInput = {
-  id: Scalars['String']['input']
-  reasonText: Scalars['String']['input']
-}
+  id: Scalars['String']['input'];
+  reasonText: Scalars['String']['input'];
+};
 
 export type BlockedResourceGql = {
-  __typename?: 'BlockedResourceGql'
-  blocked: Scalars['Boolean']['output']
-  createdAt: Scalars['DateTime']['output']
-  id: Scalars['ID']['output']
-  moderator: ModeratorGql
-  organisation: OrganisationGql
-  parentPostId?: Maybe<Scalars['String']['output']>
-  reason: BlockReasonGql
-  resourceId: Scalars['String']['output']
-  resourceType: BlockedResourceType
-  rootPostId?: Maybe<Scalars['String']['output']>
-  spaceId?: Maybe<Scalars['String']['output']>
-  updatedAt?: Maybe<Scalars['DateTime']['output']>
-}
+  __typename?: 'BlockedResourceGql';
+  blocked: Scalars['Boolean']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['ID']['output'];
+  moderator: ModeratorGql;
+  organisation: OrganisationGql;
+  parentPostId?: Maybe<Scalars['String']['output']>;
+  reason: BlockReasonGql;
+  resourceId: Scalars['String']['output'];
+  resourceType: BlockedResourceType;
+  rootPostId?: Maybe<Scalars['String']['output']>;
+  spaceId?: Maybe<Scalars['String']['output']>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+};
 
 export enum BlockedResourceType {
   Address = 'Address',
   Cid = 'CID',
-  Post = 'Post',
+  Post = 'Post'
 }
 
 export type ModeratorGql = {
-  __typename?: 'ModeratorGql'
-  firstName?: Maybe<Scalars['String']['output']>
-  id: Scalars['Int']['output']
-  lastName?: Maybe<Scalars['String']['output']>
-  organisation?: Maybe<OrganisationGql>
-  processedResources: Array<BlockedResourceGql>
-  role: ModeratorRole
-  userName?: Maybe<Scalars['String']['output']>
-}
+  __typename?: 'ModeratorGql';
+  firstName?: Maybe<Scalars['String']['output']>;
+  id: Scalars['Int']['output'];
+  lastName?: Maybe<Scalars['String']['output']>;
+  organisation?: Maybe<OrganisationGql>;
+  processedResources: Array<BlockedResourceGql>;
+  role: ModeratorRole;
+  userName?: Maybe<Scalars['String']['output']>;
+};
 
 export type ModeratorGqlInput = {
-  defaultCtxPostIds: Array<Scalars['String']['input']>
-  defaultCtxSpaceIds: Array<Scalars['String']['input']>
-  firstName: Scalars['String']['input']
-  id: Scalars['Float']['input']
-  lastName: Scalars['String']['input']
-  organisationId: Scalars['String']['input']
-  role: ModeratorRole
-  userName: Scalars['String']['input']
-}
+  defaultCtxPostIds: Array<Scalars['String']['input']>;
+  defaultCtxSpaceIds: Array<Scalars['String']['input']>;
+  firstName: Scalars['String']['input'];
+  id: Scalars['Float']['input'];
+  lastName: Scalars['String']['input'];
+  organisationId: Scalars['String']['input'];
+  role: ModeratorRole;
+  userName: Scalars['String']['input'];
+};
 
 export enum ModeratorRole {
   Admin = 'admin',
   Editor = 'editor',
-  Reader = 'reader',
+  Reader = 'reader'
 }
 
 export type Mutation = {
-  __typename?: 'Mutation'
-  createBlockReason: BlockReasonGql
-  createModerator: ModeratorGql
-  createOrganisation: OrganisationGql
-}
+  __typename?: 'Mutation';
+  createBlockReason: BlockReasonGql;
+  createModerator: ModeratorGql;
+  createOrganisation: OrganisationGql;
+};
+
 
 export type MutationCreateBlockReasonArgs = {
-  createReasonInput: BlockReasonGqlInput
-}
+  createReasonInput: BlockReasonGqlInput;
+};
+
 
 export type MutationCreateModeratorArgs = {
-  createModeratorInput: ModeratorGqlInput
-}
+  createModeratorInput: ModeratorGqlInput;
+};
+
 
 export type MutationCreateOrganisationArgs = {
-  createOrganisationInput: OrganisationGqlInput
-}
+  createOrganisationInput: OrganisationGqlInput;
+};
 
 export type OrganisationGql = {
-  __typename?: 'OrganisationGql'
-  ctxPostIds: Array<Scalars['String']['output']>
-  ctxSpaceIds: Array<Scalars['String']['output']>
-  description?: Maybe<Scalars['String']['output']>
-  id: Scalars['String']['output']
-  moderatorIds: Array<Scalars['String']['output']>
-  name?: Maybe<Scalars['String']['output']>
-  ownerId: Scalars['Int']['output']
-}
+  __typename?: 'OrganisationGql';
+  ctxPostIds: Array<Scalars['String']['output']>;
+  ctxSpaceIds: Array<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  moderatorIds: Array<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  ownerId: Scalars['Int']['output'];
+};
 
 export type OrganisationGqlInput = {
-  ctxPostIds: Array<Scalars['String']['input']>
-  ctxSpaceIds: Array<Scalars['String']['input']>
-  description?: InputMaybe<Scalars['String']['input']>
-  id: Scalars['String']['input']
-  moderatorIds: Array<Scalars['Float']['input']>
-  name?: InputMaybe<Scalars['String']['input']>
-  ownerId: Scalars['Float']['input']
-}
+  ctxPostIds: Array<Scalars['String']['input']>;
+  ctxSpaceIds: Array<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  id: Scalars['String']['input'];
+  moderatorIds: Array<Scalars['Float']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  ownerId: Scalars['Float']['input'];
+};
 
 export type Query = {
-  __typename?: 'Query'
-  blockedResourceDetailed: Array<BlockedResourceGql>
-  blockedResourceIds: Array<Scalars['String']['output']>
-  moderator: ModeratorGql
-  moderatorByUserName: ModeratorGql
-  moderatorsAll: Array<ModeratorGql>
-  reason: BlockReasonGql
-  reasonsAll: Array<BlockReasonGql>
-}
+  __typename?: 'Query';
+  blockedResourceDetailed: Array<BlockedResourceGql>;
+  blockedResourceIds: Array<Scalars['String']['output']>;
+  moderator: ModeratorGql;
+  moderatorByUserName: ModeratorGql;
+  moderatorsAll: Array<ModeratorGql>;
+  reason: BlockReasonGql;
+  reasonsAll: Array<BlockReasonGql>;
+};
+
 
 export type QueryBlockedResourceDetailedArgs = {
-  blocked?: InputMaybe<Scalars['Boolean']['input']>
-  ctxSpaceId: Scalars['String']['input']
-  moderatorId?: InputMaybe<Scalars['Float']['input']>
-  parentPostId?: InputMaybe<Scalars['String']['input']>
-  reasonId?: InputMaybe<Scalars['String']['input']>
-  resourceId?: InputMaybe<Scalars['String']['input']>
-  resourceType?: InputMaybe<BlockedResourceType>
-  rootPostId?: InputMaybe<Scalars['String']['input']>
-  spaceId?: InputMaybe<Scalars['String']['input']>
-}
+  blocked?: InputMaybe<Scalars['Boolean']['input']>;
+  ctxSpaceId: Scalars['String']['input'];
+  moderatorId?: InputMaybe<Scalars['Float']['input']>;
+  parentPostId?: InputMaybe<Scalars['String']['input']>;
+  reasonId?: InputMaybe<Scalars['String']['input']>;
+  resourceId?: InputMaybe<Scalars['String']['input']>;
+  resourceType?: InputMaybe<BlockedResourceType>;
+  rootPostId?: InputMaybe<Scalars['String']['input']>;
+  spaceId?: InputMaybe<Scalars['String']['input']>;
+};
+
 
 export type QueryBlockedResourceIdsArgs = {
-  blocked?: InputMaybe<Scalars['Boolean']['input']>
-  ctxSpaceId: Scalars['String']['input']
-  moderatorId?: InputMaybe<Scalars['Float']['input']>
-  parentPostId?: InputMaybe<Scalars['String']['input']>
-  reasonId?: InputMaybe<Scalars['String']['input']>
-  resourceId?: InputMaybe<Scalars['String']['input']>
-  resourceType?: InputMaybe<BlockedResourceType>
-  rootPostId?: InputMaybe<Scalars['String']['input']>
-  spaceId?: InputMaybe<Scalars['String']['input']>
-}
+  blocked?: InputMaybe<Scalars['Boolean']['input']>;
+  ctxSpaceId: Scalars['String']['input'];
+  moderatorId?: InputMaybe<Scalars['Float']['input']>;
+  parentPostId?: InputMaybe<Scalars['String']['input']>;
+  reasonId?: InputMaybe<Scalars['String']['input']>;
+  resourceId?: InputMaybe<Scalars['String']['input']>;
+  resourceType?: InputMaybe<BlockedResourceType>;
+  rootPostId?: InputMaybe<Scalars['String']['input']>;
+  spaceId?: InputMaybe<Scalars['String']['input']>;
+};
+
 
 export type QueryModeratorArgs = {
-  id: Scalars['Float']['input']
-}
+  id: Scalars['Float']['input'];
+};
+
 
 export type QueryModeratorByUserNameArgs = {
-  userName: Scalars['String']['input']
-}
+  userName: Scalars['String']['input'];
+};
+
 
 export type QueryReasonArgs = {
-  id: Scalars['String']['input']
-}
-
-export type GetBlockedMessageIdsInChatIdQueryVariables = Exact<{
-  ctxSpaceId: Scalars['String']['input']
-  chatId: Scalars['String']['input']
-}>
-
-export type GetBlockedMessageIdsInChatIdQuery = {
-  __typename?: 'Query'
-  blockedResourceIds: Array<string>
-}
+  id: Scalars['String']['input'];
+};
 
 export type GetBlockedCidsQueryVariables = Exact<{
-  ctxSpaceId: Scalars['String']['input']
-}>
+  ctxSpaceId: Scalars['String']['input'];
+}>;
 
-export type GetBlockedCidsQuery = {
-  __typename?: 'Query'
-  blockedResourceIds: Array<string>
-}
+
+export type GetBlockedCidsQuery = { __typename?: 'Query', blockedResourceIds: Array<string> };
 
 export type GetBlockedAddressesQueryVariables = Exact<{
-  ctxSpaceId: Scalars['String']['input']
-}>
+  ctxSpaceId: Scalars['String']['input'];
+}>;
 
-export type GetBlockedAddressesQuery = {
-  __typename?: 'Query'
-  blockedResourceIds: Array<string>
-}
 
-export const GetBlockedMessageIdsInChatId = gql`
-  query GetBlockedMessageIdsInChatId($ctxSpaceId: String!, $chatId: String!) {
-    blockedResourceIds(
-      ctxSpaceId: $ctxSpaceId
-      blocked: true
-      rootPostId: $chatId
-    )
-  }
-`
+export type GetBlockedAddressesQuery = { __typename?: 'Query', blockedResourceIds: Array<string> };
+
+
 export const GetBlockedCids = gql`
-  query GetBlockedCids($ctxSpaceId: String!) {
-    blockedResourceIds(
-      ctxSpaceId: $ctxSpaceId
-      blocked: true
-      resourceType: CID
-    )
-  }
-`
+    query GetBlockedCids($ctxSpaceId: String!) {
+  blockedResourceIds(ctxSpaceId: $ctxSpaceId, blocked: true, resourceType: CID)
+}
+    `;
 export const GetBlockedAddresses = gql`
-  query GetBlockedAddresses($ctxSpaceId: String!) {
-    blockedResourceIds(
-      ctxSpaceId: $ctxSpaceId
-      blocked: true
-      resourceType: Address
-    )
-  }
-`
+    query GetBlockedAddresses($ctxSpaceId: String!) {
+  blockedResourceIds(
+    ctxSpaceId: $ctxSpaceId
+    blocked: true
+    resourceType: Address
+  )
+}
+    `;

--- a/src/services/moderation/query.ts
+++ b/src/services/moderation/query.ts
@@ -50,7 +50,7 @@ const getBlockedMessageIdsInChatId = poolQuery<
   },
 })
 export const getBlockedMessageIdsInChatIdQuery = createQuery({
-  key: 'getBlockedMessageIdsInChatId',
+  key: 'blockedInChatId',
   fetcher: getBlockedMessageIdsInChatId,
 })
 
@@ -74,7 +74,7 @@ export async function getBlockedCids({ hubId }: { hubId: string }) {
   return data.blockedResourceIds
 }
 export const getBlockedCidsQuery = createQuery({
-  key: 'getBlockedCidsQuery',
+  key: 'blockedCids',
   fetcher: getBlockedCids,
 })
 
@@ -99,6 +99,6 @@ export async function getBlockedAddresses({ hubId }: { hubId: string }) {
   return blockedHexAddresses
 }
 export const getBlockedAddressesQuery = createQuery({
-  key: 'getBlockedAddressesQuery',
+  key: 'blockedAddresses',
   fetcher: getBlockedAddresses,
 })

--- a/src/services/moderation/query.ts
+++ b/src/services/moderation/query.ts
@@ -1,40 +1,54 @@
-import { createQuery } from '@/subsocial-query'
+import { createQuery, poolQuery } from '@/subsocial-query'
 import { gql } from 'graphql-request'
 import {
   GetBlockedAddressesQuery,
   GetBlockedAddressesQueryVariables,
   GetBlockedCidsQuery,
   GetBlockedCidsQueryVariables,
-  GetBlockedMessageIdsInChatIdQuery,
-  GetBlockedMessageIdsInChatIdQueryVariables,
 } from './generated'
 import { moderationRequest } from './utils'
 
-const GET_BLOCKED_MESSAGE_IDS_IN_CHAT_ID = gql`
-  query GetBlockedMessageIdsInChatId($ctxSpaceId: String!, $chatId: String!) {
-    blockedResourceIds(
-      ctxSpaceId: $ctxSpaceId
-      blocked: true
-      rootPostId: $chatId
-    )
-  }
-`
-export async function getBlockedMessageIdsInChatId({
-  chatId,
-  hubId,
-}: {
-  hubId: string
-  chatId: string
-}) {
-  const data = await moderationRequest<
-    GetBlockedMessageIdsInChatIdQuery,
-    GetBlockedMessageIdsInChatIdQueryVariables
-  >({
-    document: GET_BLOCKED_MESSAGE_IDS_IN_CHAT_ID,
-    variables: { chatId, ctxSpaceId: hubId },
-  })
-  return data.blockedResourceIds
+const generateBlockedMessageIdsInChatIdsQueryDocument = (
+  variables: { chatId: string; hubId: string }[]
+) => {
+  return `
+    query GetBlockedMessageIdsInChatIds {
+      ${variables.map(
+        ({ hubId, chatId }) =>
+          `SEPARATOR${hubId}SEPARATOR${chatId}: blockedResourceIds(
+            ctxSpaceId: "${hubId}"
+            blocked: true
+            rootPostId: "${chatId}"
+          )`
+      )}
+    }
+  `
 }
+const getBlockedMessageIdsInChatId = poolQuery<
+  {
+    hubId: string
+    chatId: string
+  },
+  { chatId: string; hubId: string; blockedMessageIds: string[] }
+>({
+  multiCall: async (params) => {
+    const data = await moderationRequest<Record<string, string[]>>({
+      document: generateBlockedMessageIdsInChatIdsQueryDocument(params),
+    })
+    return Object.entries(data).map(([key, res]) => {
+      const [_, chatId, hubId] = key.split('SEPARATOR')
+      return {
+        chatId,
+        hubId,
+        blockedMessageIds: res,
+      }
+    })
+  },
+  resultMapper: {
+    paramToKey: ({ chatId, hubId }) => `${hubId}-${chatId}`,
+    resultToKey: ({ chatId, hubId }) => `${hubId}-${chatId}`,
+  },
+})
 export const getBlockedMessageIdsInChatIdQuery = createQuery({
   key: 'getBlockedMessageIdsInChatId',
   fetcher: getBlockedMessageIdsInChatId,

--- a/src/services/moderation/utils.ts
+++ b/src/services/moderation/utils.ts
@@ -1,8 +1,13 @@
 import { getModerationUrl } from '@/utils/env/client'
-import request, { RequestOptions, Variables } from 'graphql-request'
+import { GraphQLClient, RequestOptions, Variables } from 'graphql-request'
 
 export function moderationRequest<T, V extends Variables = Variables>(
   config: RequestOptions<V, T>
 ) {
-  return request({ url: getModerationUrl(), ...config })
+  const TIMEOUT = 3 * 1000 // 3 seconds
+  const client = new GraphQLClient(getModerationUrl(), {
+    timeout: TIMEOUT,
+    ...config,
+  })
+  return client.request({ url: getModerationUrl(), ...config })
 }

--- a/src/services/subsocial/commentIds/query.ts
+++ b/src/services/subsocial/commentIds/query.ts
@@ -8,7 +8,7 @@ import {
   useSubscribeCommentIdsByPostIds,
 } from './subscription'
 
-const commentIdsByPostIdKey = 'commentIdsByPostId'
+const commentIdsByPostIdKey = 'comments'
 export const getCommentIdsQueryKey = createQueryKeys<string>(
   commentIdsByPostIdKey
 )

--- a/src/services/subsocial/evmAddresses/query.ts
+++ b/src/services/subsocial/evmAddresses/query.ts
@@ -24,6 +24,6 @@ const getAccountData = poolQuery<string, AccountData>({
   },
 })
 export const getAccountDataQuery = createQuery({
-  key: 'getAccountData',
+  key: 'account',
   fetcher: getAccountData,
 })

--- a/src/services/subsocial/posts/query.ts
+++ b/src/services/subsocial/posts/query.ts
@@ -39,7 +39,7 @@ const getPostIdsBySpaceId = poolQuery<
   },
 })
 export const getPostIdsBySpaceIdQuery = createSubsocialQuery({
-  key: 'getPostIdsBySpaceId',
+  key: 'postIdsBySpaceId',
   fetcher: getPostIdsBySpaceId,
 })
 
@@ -59,7 +59,7 @@ async function getFollowedPostIdsByAddress({
   return followedPostIds
 }
 export const getFollowedPostIdsByAddressQuery = createSubsocialQuery({
-  key: 'getFollowedPostIdsByAddress',
+  key: 'followedPostIdsByAddress',
   fetcher: getFollowedPostIdsByAddress,
   defaultConfigGenerator: (address) => {
     if (!address) return {}
@@ -130,6 +130,6 @@ async function getPostsByContent(search: string) {
   return res.posts.map((post) => mapPostFragment(post))
 }
 export const getPostsBySpaceContentQuery = createQuery({
-  key: 'getPostsBySpaceContent',
+  key: 'postsBySpaceContent',
   fetcher: getPostsByContent,
 })

--- a/src/services/subsocial/prices/query.ts
+++ b/src/services/subsocial/prices/query.ts
@@ -37,6 +37,6 @@ const getPrice = poolQuery<string, Price>({
   },
 })
 export const getPriceQuery = createQuery({
-  key: 'getPrices',
+  key: 'prices',
   fetcher: getPrice,
 })

--- a/src/services/subsocial/spaces/query.ts
+++ b/src/services/subsocial/spaces/query.ts
@@ -48,7 +48,7 @@ const getSpaceFromSquid = poolQuery<string, SpaceData>({
   },
 })
 
-export const getSpaceQuery = createDynamicSubsocialQuery('getSpace', {
+export const getSpaceQuery = createDynamicSubsocialQuery('space', {
   blockchain: getSpaceFromBlockchain,
   squid: getSpaceFromSquid,
 })

--- a/src/services/subsocial/squid/mappers.ts
+++ b/src/services/subsocial/squid/mappers.ts
@@ -16,7 +16,7 @@ import {
 
 const SQUID_SEPARATOR = ','
 const getTokensFromUnifiedString = (data: string | null) =>
-  data?.split(SQUID_SEPARATOR) ?? []
+  data?.split(SQUID_SEPARATOR).filter(Boolean) ?? []
 
 export const mapSpaceFragment = (space: SpaceFragmentFragment): SpaceData => {
   return {

--- a/src/utils/page.ts
+++ b/src/utils/page.ts
@@ -1,4 +1,5 @@
 import { AppCommonProps } from '@/pages/_app'
+import { dehydrate, DehydratedState, QueryClient } from '@tanstack/react-query'
 import {
   GetServerSideProps,
   GetServerSidePropsContext,
@@ -63,5 +64,50 @@ export function getCommonServerSideProps<ReturnValue>(
         ...data.props,
       },
     }
+  }
+}
+
+type DehydratedQueries = (Pick<
+  DehydratedState['queries'][number],
+  'queryHash' | 'queryKey'
+> & { data: unknown })[]
+export function dehydrateQueries(client: QueryClient): DehydratedQueries {
+  const dehydratedState = dehydrate(client)
+  const processedQueries: DehydratedQueries = []
+
+  dehydratedState.queries.forEach((query) => {
+    if (query.state.status !== 'success') return
+    processedQueries.push({
+      queryKey: query.queryKey,
+      queryHash: query.queryHash,
+      data: query.state.data ?? null,
+    })
+  })
+
+  return processedQueries
+}
+export function parseDehydratedState(
+  dehydratedQueries: DehydratedQueries
+): DehydratedState {
+  return {
+    mutations: [],
+    queries: dehydratedQueries.map(({ data, queryHash, queryKey }) => ({
+      queryKey,
+      queryHash,
+      state: {
+        data,
+        dataUpdateCount: 0,
+        dataUpdatedAt: Date.now(),
+        error: null,
+        errorUpdateCount: 0,
+        errorUpdatedAt: 0,
+        fetchFailureCount: 0,
+        fetchFailureReason: null,
+        fetchMeta: null,
+        fetchStatus: 'idle' as const,
+        isInvalidated: false,
+        status: 'success' as const,
+      },
+    })),
   }
 }


### PR DESCRIPTION
# Moderation Queries
Batch the calls to get `blockedResourceIds` per chat ids. Now for example, in home page, because its rendering 2 spaces (decoded and x), it will get all the blocked resource per all chats, so it will get about 87 (decoded) and 24 (grill) calls at once.

Now all those calls are batched, so per home page request (every 2 secs), it will call only 3 calls to moderation (blocked addresses, blocked contents, and 1 batched call for all blocked resource ids per chats), instead of 87+24+2 calls.

# React Query Hydration
Reduce __NEXT_DATA__ size as in home page currently, its about 300kb of __NEXT_DATA__ which creates warning
```
Warning: data for page "/" is 294 kB which exceeds the threshold of 128 kB, this amount of data can reduce performance.
See more info here: https://nextjs.org/docs/messages/large-page-data
```

Most of the cause why its this big is because react query hydration. There are too many data being fetched that needs to be passed to client.

To solve this:
1. Remove the unimportant state duplication data that is passed for every cache result, like `{error: null,updatedAt:...}` and just create those data in client side.
![image](https://github.com/dappforce/grillchat/assets/53143942/b5592463-b978-498a-b3b5-e32aa624fba0)
2. Reduce the query name length (`getSpaces` to `spaces`, etc.).
3. Remove the queryHash data passed, instead pass only the queryKey, and hash it in client.

With above solutions, it managed to reduce the size from 294kb to 171kb for the home page.

Because its still above the threshold, **I just increase the threshold to 200kb**. 
This issue should be solved completely in the next data hub implementation, because one of the reason it needs so much data fetched is:
To get the last message blocked. currently it needs:
1. all the comment ids in every chats
2. blocked message ids in every chats
3. last message post data
4. blocked contents
5. blocked addresses

# Reduce Bundle Size
Use dynamic imports for extension components, and reduce the first load js from ~700kb to ~400kb for home and chat page 