### PR TITLE
Remove dehydrating optimization, because it makes web slow

### DIFF
--- a/src/pages/[hubId]/[slug]/index.tsx
+++ b/src/pages/[hubId]/[slug]/index.tsx
@@ -14,10 +14,10 @@ import {
   getPriceQuery,
 } from '@/services/subsocial/prices/query'
 import { getSubsocialApi } from '@/subsocial-query/subsocial/connection'
-import { dehydrateQueries, getCommonStaticProps } from '@/utils/page'
+import { getCommonStaticProps } from '@/utils/page'
 import { getIdFromSlug } from '@/utils/slug'
 import { validateNumber } from '@/utils/strings'
-import { QueryClient } from '@tanstack/react-query'
+import { dehydrate, QueryClient } from '@tanstack/react-query'
 import { GetStaticPaths } from 'next'
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -125,7 +125,7 @@ export const getStaticProps = getCommonStaticProps<
 
     return {
       props: {
-        dehydratedState: dehydrateQueries(queryClient),
+        dehydratedState: dehydrate(queryClient),
         chatId,
         hubId,
         head: {

--- a/src/pages/[hubId]/index.tsx
+++ b/src/pages/[hubId]/index.tsx
@@ -2,9 +2,9 @@ import { getHubIdFromAlias } from '@/constants/hubs'
 import HubPage, { HubPageProps } from '@/modules/chat/HubPage'
 import { prefetchChatPreviewsData } from '@/server/chats'
 import { getMainHubId } from '@/utils/env/client'
-import { dehydrateQueries, getCommonStaticProps } from '@/utils/page'
+import { getCommonStaticProps } from '@/utils/page'
 import { validateNumber } from '@/utils/strings'
-import { QueryClient } from '@tanstack/react-query'
+import { dehydrate, QueryClient } from '@tanstack/react-query'
 import { AppCommonProps } from '../_app'
 
 export const getStaticPaths = async () => {
@@ -48,7 +48,7 @@ export const getStaticProps = getCommonStaticProps<
 
     return {
       props: {
-        dehydratedState: dehydrateQueries(queryClient),
+        dehydratedState: dehydrate(queryClient),
         hubId,
       },
       revalidate: 2,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,14 +8,13 @@ import { initAllStores } from '@/stores/registry'
 import '@/styles/globals.css'
 import { cx } from '@/utils/class-names'
 import { getGaId } from '@/utils/env/client'
-import { parseDehydratedState } from '@/utils/page'
 import '@rainbow-me/rainbowkit/styles.css'
 import { ThemeProvider } from 'next-themes'
 import type { AppProps } from 'next/app'
 import { Source_Sans_Pro } from 'next/font/google'
 import { GoogleAnalytics } from 'nextjs-google-analytics'
 import NextNProgress from 'nextjs-progressbar'
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { Toaster } from 'react-hot-toast'
 
 export type AppCommonProps = {
@@ -69,10 +68,6 @@ export default function App(props: AppProps<AppCommonProps>) {
 
 function AppContent({ Component, pageProps }: AppProps<AppCommonProps>) {
   const { head, dehydratedState, ...props } = pageProps
-  const parsedDehydratedState = useMemo(
-    () => parseDehydratedState(dehydratedState),
-    [dehydratedState]
-  )
 
   const isInitialized = useRef(false)
   const { theme } = useConfigContext()
@@ -92,7 +87,7 @@ function AppContent({ Component, pageProps }: AppProps<AppCommonProps>) {
 
   return (
     <ThemeProvider attribute='class' forcedTheme={theme}>
-      <QueryProvider dehydratedState={parsedDehydratedState}>
+      <QueryProvider dehydratedState={dehydratedState}>
         <ToasterConfig />
         <NextNProgress
           color='#4d46dc'

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,8 +8,8 @@ import { prefetchChatPreviewsData } from '@/server/chats'
 import { getPostIdsBySpaceIdQuery } from '@/services/subsocial/posts'
 import { getSpaceQuery } from '@/services/subsocial/spaces'
 import { getHubIds, getMainHubId } from '@/utils/env/client'
-import { dehydrateQueries, getCommonStaticProps } from '@/utils/page'
-import { QueryClient } from '@tanstack/react-query'
+import { getCommonStaticProps } from '@/utils/page'
+import { dehydrate, QueryClient } from '@tanstack/react-query'
 
 export const getStaticProps = getCommonStaticProps<
   HubsPageProps & AppCommonProps
@@ -46,7 +46,7 @@ export const getStaticProps = getCommonStaticProps<
 
     return {
       props: {
-        dehydratedState: dehydrateQueries(queryClient),
+        dehydratedState: dehydrate(queryClient),
         hubsChatCount,
         isIntegrateChatButtonOnTop: Math.random() > 0.5,
       },

--- a/src/utils/page.ts
+++ b/src/utils/page.ts
@@ -1,11 +1,5 @@
 import { AppCommonProps } from '@/pages/_app'
 import {
-  dehydrate,
-  DehydratedState,
-  hashQueryKey,
-  QueryClient,
-} from '@tanstack/react-query'
-import {
   GetServerSideProps,
   GetServerSidePropsContext,
   GetStaticProps,
@@ -69,53 +63,5 @@ export function getCommonServerSideProps<ReturnValue>(
         ...data.props,
       },
     }
-  }
-}
-
-type DehydratedQueries = (Pick<
-  DehydratedState['queries'][number],
-  'queryKey'
-> & { data: unknown })[]
-export function dehydrateQueries(client: QueryClient): DehydratedQueries {
-  const dehydratedState = dehydrate(client)
-  const processedQueries: DehydratedQueries = []
-
-  dehydratedState.queries.forEach((query) => {
-    if (query.state.status !== 'success') return
-    processedQueries.push({
-      queryKey: query.queryKey,
-      data: query.state.data ?? null,
-    })
-  })
-
-  return processedQueries
-}
-export function parseDehydratedState(
-  dehydratedQueries?: DehydratedQueries
-): DehydratedState | undefined {
-  if (!dehydratedQueries) {
-    return undefined
-  }
-
-  return {
-    mutations: [],
-    queries: dehydratedQueries.map(({ data, queryKey }) => ({
-      queryKey,
-      queryHash: hashQueryKey(queryKey),
-      state: {
-        data,
-        dataUpdateCount: 0,
-        dataUpdatedAt: Date.now(),
-        error: null,
-        errorUpdateCount: 0,
-        errorUpdatedAt: 0,
-        fetchFailureCount: 0,
-        fetchFailureReason: null,
-        fetchMeta: null,
-        fetchStatus: 'idle' as const,
-        isInvalidated: false,
-        status: 'success' as const,
-      },
-    })),
   }
 }


### PR DESCRIPTION
I checked, and found that the useMemo for parseDehydratedQueries are called so many times, making changing route slower