### PR TITLE
Minor Fixes

### DIFF
--- a/src/components/AddressAvatar.tsx
+++ b/src/components/AddressAvatar.tsx
@@ -43,7 +43,8 @@ const AddressAvatar = forwardRef<HTMLDivElement, AddressAvatarProps>(
             className={cx(
               'bg-background-light',
               'rounded-full',
-              'h-9 w-9 self-center sm:h-9 sm:w-9'
+              'h-9 w-9 self-center',
+              props.className
             )}
           ></div>
         </div>
@@ -55,7 +56,7 @@ const AddressAvatar = forwardRef<HTMLDivElement, AddressAvatarProps>(
         {...props}
         ref={ref}
         className={cx(
-          'relative h-9 w-9 overflow-hidden rounded-full bg-background-lightest',
+          'relative h-9 w-9 flex-shrink-0 overflow-hidden rounded-full bg-background-lightest',
           props.className
         )}
         style={{ backgroundColor }}

--- a/src/components/ProfilePreviewModalWrapper.tsx
+++ b/src/components/ProfilePreviewModalWrapper.tsx
@@ -1,5 +1,9 @@
+import { getAccountDataQuery } from '@/services/subsocial/evmAddresses'
+import { useExtensionData } from '@/stores/extension'
 import { cx } from '@/utils/class-names'
 import { useState } from 'react'
+import { RiCopperCoinLine } from 'react-icons/ri'
+import ActionCard from './ActionCard'
 import Modal from './modals/Modal'
 import Name, { NameProps } from './Name'
 import ProfilePreview from './ProfilePreview'
@@ -15,7 +19,12 @@ export default function ProfilePreviewModalWrapper({
   address,
   children,
 }: ProfilePreviewModalWrapperProps) {
+  const openExtensionModal = useExtensionData(
+    (state) => state.openExtensionModal
+  )
   const [isOpenAccountModal, setIsOpenAccountModal] = useState(false)
+  const { data: accountData } = getAccountDataQuery.useQuery(address)
+  const { evmAddress } = accountData || {}
 
   return (
     <>
@@ -30,6 +39,22 @@ export default function ProfilePreviewModalWrapper({
         closeModal={() => setIsOpenAccountModal(false)}
       >
         <ProfilePreview address={address} className='mb-2' />
+        {evmAddress && (
+          <ActionCard
+            className='mt-2'
+            actions={[
+              {
+                icon: RiCopperCoinLine,
+                text: 'Donate',
+                iconClassName: cx('text-text-muted'),
+                onClick: () =>
+                  openExtensionModal('subsocial-donations', {
+                    recipient: address,
+                  }),
+              },
+            ]}
+          />
+        )}
       </Modal>
     </>
   )

--- a/src/components/chats/ChatPreview/ChatPreview.tsx
+++ b/src/components/chats/ChatPreview/ChatPreview.tsx
@@ -129,7 +129,7 @@ export default function ChatPreview({
               )}
               {renderAdditionalData()}
             </div>
-            <div className='mt-1 flex items-baseline justify-between overflow-hidden'>
+            <div className='mt-0.5 flex items-baseline justify-between overflow-hidden'>
               {chatId && hubId ? (
                 <ChatLastMessage
                   hubId={hubId}

--- a/src/components/extensions/config.ts
+++ b/src/components/extensions/config.ts
@@ -30,7 +30,10 @@ const NftRepliedMessagePreviewPart = dynamic(
 )
 
 export const extensionInitialDataTypes = {
-  'subsocial-donations': { recipient: '', messageId: '' },
+  'subsocial-donations': { recipient: '' } as {
+    recipient: string
+    messageId?: string
+  },
   'subsocial-evm-nft': null as null | string,
   'subsocial-image': null as null | File | string,
   'subsocial-decoded-promo': { recipient: '', messageId: '' },

--- a/src/components/extensions/image/ImageModal.tsx
+++ b/src/components/extensions/image/ImageModal.tsx
@@ -85,7 +85,7 @@ export default function ImageModal({ chatId, onSubmit }: ExtensionModalsProps) {
         )}
 
         {!isAnyShowingImage && (
-          <div className='relative my-2 flex items-center justify-center'>
+          <div className='relative flex items-center justify-center'>
             <div className='absolute top-1/2 h-px w-full bg-border-gray' />
             <span className='relative bg-background-light px-3 text-xs text-text-muted'>
               OR

--- a/src/components/inputs/TextArea.tsx
+++ b/src/components/inputs/TextArea.tsx
@@ -1,6 +1,13 @@
 import { cx, scrollBarStyles } from '@/utils/class-names'
 import { isTouchDevice } from '@/utils/device'
-import { ComponentProps, forwardRef, KeyboardEventHandler } from 'react'
+import {
+  ComponentProps,
+  forwardRef,
+  KeyboardEventHandler,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from 'react'
 import FieldWrapper, {
   getCleanedInputProps,
   RequiredFieldWrapperProps,
@@ -14,6 +21,23 @@ export type TextAreaProps = ComponentProps<'textarea'> &
 
 const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   function TextArea({ onEnterToSubmitForm, ...props }: TextAreaProps, ref) {
+    const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
+    const replicatedRef = useRef<HTMLDivElement | null>(null)
+    useImperativeHandle<HTMLTextAreaElement | null, HTMLTextAreaElement | null>(
+      ref,
+      () => textAreaRef.current
+    )
+
+    useEffect(() => {
+      const textArea = textAreaRef.current
+      const replicated = replicatedRef.current
+
+      if (!textArea || !replicated) return
+      textArea.addEventListener('input', (e) => {
+        replicated.textContent = (e.target as HTMLTextAreaElement)?.value + ' '
+      })
+    }, [])
+
     const onKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
       if (!isTouchDevice() && e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault()
@@ -36,11 +60,11 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
               <textarea
                 {...getCleanedInputProps(props)}
                 onKeyDown={onKeyDown}
-                ref={ref}
+                ref={textAreaRef}
                 id={id}
                 className={textAreaClassName}
               />
-              <div className={textAreaClassName}>{props.value}</div>
+              <div ref={replicatedRef} className={textAreaClassName} />
             </div>
           )
         }}

--- a/src/components/modals/MetadataModal.tsx
+++ b/src/components/modals/MetadataModal.tsx
@@ -3,6 +3,7 @@ import Modal, {
   ModalProps,
 } from '@/components/modals/Modal'
 import { getIpfsContentUrl, getSubIdUrl } from '@/utils/ipfs'
+import { getPolkadotJsUrl } from '@/utils/links'
 import { PostData, SpaceData } from '@subsocial/api/types'
 import DataCard, { DataCardProps } from '../DataCard'
 
@@ -22,6 +23,10 @@ export default function MetadataModal({
       title: `${postIdTextPrefix} ID:`,
       content: entity.id,
       withCopyButton: true,
+      redirectTo: entity.struct.createdAtBlock
+        ? getPolkadotJsUrl(`/explorer/query/${entity.struct.createdAtBlock}`)
+        : undefined,
+      openInNewTab: true,
     },
     {
       title: 'Content ID:',

--- a/src/modules/chat/HomePage/HomePage.tsx
+++ b/src/modules/chat/HomePage/HomePage.tsx
@@ -34,6 +34,12 @@ export const homePageAdditionalTabs: {
   // },
 ]
 
+const pathnameTabIdMapper: Record<string, number> = {
+  '/my-chats': 0,
+  '/hot-chats': 1,
+  '/hubs': 2,
+}
+
 export default function HubsPage(props: HubsPageProps) {
   const router = useRouter()
   const { search, setSearch, getFocusedElementIndex, focusController } =
@@ -74,8 +80,13 @@ export default function HubsPage(props: HubsPageProps) {
     myAddress ?? addressFromStorage ?? ''
   )
 
-  const [isTabUrlLoaded, setIsTabUrlLoaded] = useState(false)
-  const [selectedTab, setSelectedTab] = useState(1)
+  const currentTabId = pathnameTabIdMapper[router.asPath.split('?')[0]]
+  console.log(router.asPath)
+  const [isTabUrlLoaded, setIsTabUrlLoaded] = useState(
+    typeof currentTabId === 'number'
+  )
+  const [selectedTab, setSelectedTab] = useState(currentTabId)
+
   useEffect(() => {
     if (!router.isReady) return
 
@@ -93,6 +104,7 @@ export default function HubsPage(props: HubsPageProps) {
       if (index > -1) setSelectedTab(index)
     }
 
+    console.log('setting')
     setIsTabUrlLoaded(true)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router])

--- a/src/modules/chat/HomePage/HomePage.tsx
+++ b/src/modules/chat/HomePage/HomePage.tsx
@@ -108,7 +108,6 @@ export default function HubsPage(props: HubsPageProps) {
       if (index > -1) setSelectedTab(index)
     }
 
-    console.log('setting')
     setIsTabUrlLoaded(true)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router])

--- a/src/modules/chat/HomePage/HomePage.tsx
+++ b/src/modules/chat/HomePage/HomePage.tsx
@@ -3,6 +3,7 @@ import NavbarWithSearch from '@/components/navbar/Navbar/custom/NavbarWithSearch
 import Tabs, { TabsProps } from '@/components/Tabs'
 import useSearch from '@/hooks/useSearch'
 import { getFollowedPostIdsByAddressQuery } from '@/services/subsocial/posts'
+import { useLocation } from '@/stores/location'
 import { accountAddressStorage, useMyAccount } from '@/stores/my-account'
 import { getMainHubId } from '@/utils/env/client'
 import { replaceUrl } from '@/utils/window'
@@ -42,6 +43,7 @@ const pathnameTabIdMapper: Record<string, number> = {
 
 export default function HubsPage(props: HubsPageProps) {
   const router = useRouter()
+  const isFirstAccessed = useLocation((state) => state.isFirstAccessed)
   const { search, setSearch, getFocusedElementIndex, focusController } =
     useSearch()
 
@@ -80,12 +82,14 @@ export default function HubsPage(props: HubsPageProps) {
     myAddress ?? addressFromStorage ?? ''
   )
 
-  const currentTabId = pathnameTabIdMapper[router.asPath.split('?')[0]]
-  console.log(router.asPath)
+  // If user is accessing page for the first time, we can't use the `asPath` because it will cause hydration error because of rewrites
+  const currentTabId = isFirstAccessed
+    ? undefined
+    : pathnameTabIdMapper[router.asPath.split('?')[0]]
   const [isTabUrlLoaded, setIsTabUrlLoaded] = useState(
     typeof currentTabId === 'number'
   )
-  const [selectedTab, setSelectedTab] = useState(currentTabId)
+  const [selectedTab, setSelectedTab] = useState(currentTabId ?? 1)
 
   useEffect(() => {
     if (!router.isReady) return

--- a/src/pages/[hubId]/[slug]/index.tsx
+++ b/src/pages/[hubId]/[slug]/index.tsx
@@ -87,6 +87,11 @@ export const getStaticProps = getCommonStaticProps<
           prefetchBlockedEntities(queryClient, hubId, [chatId]),
         ] as const)
 
+      const originalHubId = chatData.struct.spaceId
+      if (originalHubId && originalHubId !== hubId) {
+        await prefetchBlockedEntities(queryClient, originalHubId, [chatId])
+      }
+
       title = chatData?.content?.title || null
       desc = chatData?.content?.body || null
 

--- a/src/stores/extension.ts
+++ b/src/stores/extension.ts
@@ -30,8 +30,8 @@ export const useExtensionData = create<State & Actions>()((set, get) => ({
       _extensionModalStates: {
         ...get()._extensionModalStates,
         [id]: {
+          ...get()._extensionModalStates[id],
           isOpen: false,
-          initialData: null,
         },
       },
     })
@@ -42,7 +42,7 @@ export const useExtensionData = create<State & Actions>()((set, get) => ({
         ...get()._extensionModalStates,
         [id]: {
           isOpen: true,
-          initialData,
+          initialData: initialData ?? null,
         },
       },
     })

--- a/src/stores/location.ts
+++ b/src/stores/location.ts
@@ -7,11 +7,13 @@ let startHistoryLength: number
 type State = {
   currentUrl: string
   prevUrl: string | undefined
+  isFirstAccessed: boolean
 }
 
 const initialState: State = {
   currentUrl: '',
   prevUrl: undefined,
+  isFirstAccessed: true,
 }
 
 export const useLocation = create<State>()((set, get) => ({
@@ -41,6 +43,7 @@ export const useLocation = create<State>()((set, get) => ({
       set({
         currentUrl: window.location.href,
         prevUrl: lastHistory,
+        isFirstAccessed: false,
       })
     })
   },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -44,6 +44,12 @@
   --border-gray: 51 59 74;
 }
 
+@media screen and (max-width: 375px) {
+  :root {
+    font-size: 0.875rem;
+  }
+}
+
 .grecaptcha-badge {
   visibility: hidden;
   display: none;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,7 +4,7 @@
   --background-lighter: 236 239 244;
   --background-lightest: 219 222 230;
   --background-primary: 77 70 220;
-  --background-primary-light: 216 214 255;
+  --background-primary-light: 224 225 254;
   --background-warning: 225 181 62;
   --background-info: 77 70 220;
   --background-accent: 236 239 244;

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -1,4 +1,6 @@
+import { SUBSTRATE_URL } from '@/constants/subsocial'
 import { ParsedUrlQuery } from 'querystring'
+import urlJoin from 'url-join'
 
 export function getUrlQuery(queryName: string) {
   const query = window.location.search
@@ -41,4 +43,11 @@ export function getChatPageLink(
 export function validateVideoUrl(url: string) {
   const videoFileUrlRegex = /\.(mp4|mov|avi|wmv|flv|mkv)$/i
   return videoFileUrlRegex.test(url)
+}
+
+export function getPolkadotJsUrl(pathname?: string) {
+  return urlJoin(
+    `https://polkadot.js.org/apps/?rpc=${SUBSTRATE_URL}/#/`,
+    pathname ?? ''
+  )
 }


### PR DESCRIPTION
# Fixes
- Make address avatar not shrinkable
- Add donate button in profile preview modal
- Reduce margin in image modal
- Fix issue with scroll restoration not working in home page
- Prefetch blocked entities for chats in its original hub too
- Improve extension UX by not clearing initial data when closing (so the modal won't change content when its animating close, can be seen in donation modal)
- Change color for my message in light mode
- Reduce scale of all the app when in super small screen (< 375px)
- Improve textarea autogrow, fix issue where it doesn't grow when shift+enter. Also, before it doesn't support uncontrolled input, now it does.
- Add redirect for metadata ids to polkadot js block data