### PR TITLE
Fix issue EVM address is not whitelisted correctly

### DIFF
--- a/src/components/chats/ChatRoom/ChatInputBar.tsx
+++ b/src/components/chats/ChatRoom/ChatInputBar.tsx
@@ -24,7 +24,7 @@ export default function ChatInputBar({
 
   const isWhitelisted =
     whitelistedAddresses?.includes(myAddress ?? '') ||
-    whitelistedAddresses?.includes(myEvmAddress ?? '')
+    whitelistedAddresses?.includes(myEvmAddress?.toLowerCase() ?? '')
 
   if (whitelistedAddresses && (!myAddress || !isWhitelisted)) {
     return null

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -14,8 +14,10 @@ const WHITELISTED_ADDRESSES_IN_CHAT_ID: Record<string, string[]> = {
     '3rJPTPXHEq6sXeXK4CCgSnWhmakfpG4DknH62P616Zyr9XLz',
     '3q5o5HibyHXYrwVMinjcL4j95SDVNmLE46pu9Z5C8RTiWzwh',
     '3tATRYq6yiws8B8WhLxEuNPFtpLFh8xxe2K2Lnt8NTrjXk8N',
-    '0x8f7131da7c374566aD3084049d4E1806Ed183a27',
-    '0x26674D44c3a4c145482Dd360069a8e5Fee2Ec74C',
+
+    // EVM addresses need to be lower cased, because the casing might be different in different circumstances
+    '0x8f7131da7c374566ad3084049d4e1806ed183a27',
+    '0x26674d44c3a4c145482dd360069a8e5fee2ec74c',
   ],
 }
 export function getWhitelistedAddressesInChatId(chatId: string) {


### PR DESCRIPTION
Issue: The EVM address casing might be different at different circumstances, making the includes function not detecting the address.

Solution: lowercase the whitelist and checking part