### PR TITLE
Queued events if amp is not init yet

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -89,6 +89,7 @@ function AppContent({ Component, pageProps }: AppProps<AppCommonProps>) {
   const isInIframe = useIsInIframe()
   useEffect(() => {
     if (!isInIframe) return
+    console.log('KEPANGGIL!!')
     sendEvent('loaded in iframe')
   }, [isInIframe, sendEvent])
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -89,7 +89,6 @@ function AppContent({ Component, pageProps }: AppProps<AppCommonProps>) {
   const isInIframe = useIsInIframe()
   useEffect(() => {
     if (!isInIframe) return
-    console.log('KEPANGGIL!!')
     sendEvent('loaded in iframe')
   }, [isInIframe, sendEvent])
 

--- a/src/stores/analytics.ts
+++ b/src/stores/analytics.ts
@@ -14,6 +14,8 @@ type Actions = {
   _updateUserId: (address: string | undefined) => void
 }
 
+const queuedEvents: { name: string; properties?: Record<string, string> }[] = []
+
 const initialState: State = {
   amp: null,
   userId: undefined,
@@ -51,7 +53,9 @@ export const useAnalytics = create<State & Actions>()((set, get) => ({
       ...properties,
     }
 
-    amp?.logEvent(name, mergedProperties)
+    if (!amp) queuedEvents.push({ name, properties: mergedProperties })
+    else amp?.logEvent(name, mergedProperties)
+
     event(name, {
       userId,
     })
@@ -61,6 +65,9 @@ export const useAnalytics = create<State & Actions>()((set, get) => ({
     const amp = await createAmplitudeInstance()
 
     set({ amp })
+    queuedEvents.forEach(({ name, properties }) => {
+      amp?.logEvent(name, properties)
+    })
   },
 }))
 


### PR DESCRIPTION
# Issue
I think the loaded in iframe event most of the time are not logged correctly. This is because the amp is not ready yet, but the logEvent is called already.

# Solution
Queue the events if the amp is not ready yet, and call them after the amp is initialized