### PR TITLE
Fix Join Button Showing Briefly Issue

### DIFF
--- a/src/components/navbar/Navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar/Navbar.tsx
@@ -13,10 +13,8 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { ComponentProps, useEffect, useRef, useState } from 'react'
 import { HiOutlineChevronLeft } from 'react-icons/hi2'
+import ProfileAvatar from './ProfileAvatar'
 
-const ProfileAvatar = dynamic(() => import('./ProfileAvatar'), {
-  ssr: false,
-})
 const LoginModal = dynamic(() => import('@/components/auth/LoginModal'), {
   ssr: false,
 })

--- a/src/components/navbar/Navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar/Navbar.tsx
@@ -13,8 +13,11 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { ComponentProps, useEffect, useRef, useState } from 'react'
 import { HiOutlineChevronLeft } from 'react-icons/hi2'
-import ProfileAvatar from './ProfileAvatar'
 
+const ProfileAvatar = dynamic(() => import('./ProfileAvatar'), {
+  ssr: false,
+  loading: () => <div className='w-9' />,
+})
 const LoginModal = dynamic(() => import('@/components/auth/LoginModal'), {
   ssr: false,
 })

--- a/src/components/navbar/Navbar/ProfileAvatar.tsx
+++ b/src/components/navbar/Navbar/ProfileAvatar.tsx
@@ -1,10 +1,14 @@
 import AddressAvatar from '@/components/AddressAvatar'
-import ProfileModal from '@/components/auth/ProfileModal'
 import PopOver from '@/components/floating/PopOver'
 import { cx } from '@/utils/class-names'
 import { getCurrentUrlWithoutQuery, getUrlQuery } from '@/utils/links'
 import { replaceUrl } from '@/utils/window'
+import dynamic from 'next/dynamic'
 import { ComponentProps, useEffect, useState } from 'react'
+
+const ProfileModal = dynamic(() => import('@/components/auth/ProfileModal'), {
+  ssr: false,
+})
 
 export type ProfileAvatarProps = ComponentProps<'div'> & {
   address: string

--- a/src/components/navbar/Navbar/ProfileAvatar.tsx
+++ b/src/components/navbar/Navbar/ProfileAvatar.tsx
@@ -1,14 +1,10 @@
 import AddressAvatar from '@/components/AddressAvatar'
+import ProfileModal from '@/components/auth/ProfileModal'
 import PopOver from '@/components/floating/PopOver'
 import { cx } from '@/utils/class-names'
 import { getCurrentUrlWithoutQuery, getUrlQuery } from '@/utils/links'
 import { replaceUrl } from '@/utils/window'
-import dynamic from 'next/dynamic'
 import { ComponentProps, useEffect, useState } from 'react'
-
-const ProfileModal = dynamic(() => import('@/components/auth/ProfileModal'), {
-  ssr: false,
-})
 
 export type ProfileAvatarProps = ComponentProps<'div'> & {
   address: string

--- a/src/hooks/useIsJoinedToChat.ts
+++ b/src/hooks/useIsJoinedToChat.ts
@@ -11,16 +11,13 @@ const isJoinedValue = {
 export default function useIsJoinedToChat(chatId: string, address?: string) {
   const isInIframe = useIsInIframe()
 
-  const isInitialized = useMyAccount((state) => state.isInitialized)
   const myAddress = useMyAccount((state) => state.address)
   const usedAddress = address || myAddress
 
-  const isEnabledQuery = isInitialized && !!usedAddress
+  const isEnabledQuery = !!usedAddress
   const { data, isLoading } = getFollowedPostIdsByAddressQuery.useQuery(
     usedAddress ?? '',
-    {
-      enabled: isEnabledQuery,
-    }
+    { enabled: isEnabledQuery }
   )
 
   const followedPostIdsSet = useMemo(() => {

--- a/src/stores/my-account.ts
+++ b/src/stores/my-account.ts
@@ -119,7 +119,8 @@ export const useMyAccount = create<State & Actions>()((set, get) => ({
 
     // Prevent multiple initialization
     if (isInitialized !== undefined) return
-    set({ isInitialized: false })
+    const storageAddress = accountAddressStorage.get()
+    set({ isInitialized: false, address: storageAddress || undefined })
 
     const encodedSecretKey = accountStorage.get()
     if (encodedSecretKey) {

--- a/src/stores/my-account.ts
+++ b/src/stores/my-account.ts
@@ -119,15 +119,21 @@ export const useMyAccount = create<State & Actions>()((set, get) => ({
 
     // Prevent multiple initialization
     if (isInitialized !== undefined) return
-    const storageAddress = accountAddressStorage.get()
-    set({ isInitialized: false, address: storageAddress || undefined })
+    set({ isInitialized: false })
 
     const encodedSecretKey = accountStorage.get()
     if (encodedSecretKey) {
+      const storageAddress = accountAddressStorage.get()
+      set({ address: storageAddress || undefined })
+
       const secretKey = decodeSecretKey(encodedSecretKey)
       const address = await login(secretKey, true)
 
-      if (!address) accountStorage.remove()
+      if (!address) {
+        accountStorage.remove()
+        accountAddressStorage.remove()
+        set({ address: null })
+      }
     }
 
     set({ isInitialized: true })


### PR DESCRIPTION
# Issue
The join button still shows for ~1s after user refreshes on a chat page
This issue was because the initialization process takes pretty long time because it imports pretty heavy things when logging in with the private key

# Solution
Temporarily set the address from the account address storage (local storage) and use that value so the chat page can immediately show either join button or input based on that (instead of based on after logging in with private key)