### PR TITLE
Improve experience for displaying address avatar

### DIFF
--- a/src/components/AddressAvatar.tsx
+++ b/src/components/AddressAvatar.tsx
@@ -20,7 +20,7 @@ const AddressAvatar = forwardRef<HTMLDivElement, AddressAvatarProps>(
       theme: 'dark',
     })
 
-    const [ensAvatarLoaded, setEnsAvatarLoaded] = useState(false)
+    const [isEnsAvatarError, setIsEnsAvatarError] = useState(false)
 
     const { data: accountData, isLoading } =
       getAccountDataQuery.useQuery(address)
@@ -68,7 +68,7 @@ const AddressAvatar = forwardRef<HTMLDivElement, AddressAvatarProps>(
           <div
             className={cx(
               'absolute inset-0 h-full w-full transition-opacity',
-              ensAvatarLoaded ? 'z-10 opacity-100' : '-z-10 opacity-0'
+              !isEnsAvatarError ? 'z-10 opacity-100' : '-z-10 opacity-0'
             )}
           >
             <div className='relative h-full w-full'>
@@ -77,7 +77,7 @@ const AddressAvatar = forwardRef<HTMLDivElement, AddressAvatarProps>(
                 className='relative rounded-full'
                 fill
                 src={resolveEnsAvatarSrc(ensName)}
-                onLoad={() => setEnsAvatarLoaded(true)}
+                onError={() => setIsEnsAvatarError(true)}
                 alt='avatar'
               />
             </div>


### PR DESCRIPTION
# Issue
When changing page, the navbar's avatar blinks, showing the autogenerated avatar first, then the ens avatar.
This is because the showing of ens avatar have delay because it needs to run 1 setstate before it shows the ens avatar

# Solution
Rather than show on finish load, change to hide on error, so it will be displayed as default, and won't blink if its already loaded