### PR TITLE
Remove bell icon in iframe

### DIFF
--- a/src/components/navbar/Navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar/Navbar.tsx
@@ -2,6 +2,7 @@ import BackButton from '@/components/BackButton'
 import Button from '@/components/Button'
 import Container from '@/components/Container'
 import Logo from '@/components/Logo'
+import useIsInIframe from '@/hooks/useIsInIframe'
 import usePrevious from '@/hooks/usePrevious'
 import { useConfigContext } from '@/providers/ConfigProvider'
 import { getBlockedResourcesQuery } from '@/services/api/moderation/query'
@@ -14,7 +15,14 @@ import { LocalStorage } from '@/utils/storage'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { ComponentProps, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ComponentProps,
+  ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { HiOutlineBell, HiOutlineChevronLeft } from 'react-icons/hi2'
 
 const ProfileAvatar = dynamic(() => import('./ProfileAvatar'), {
@@ -31,10 +39,10 @@ export type NavbarProps = ComponentProps<'div'> & {
     forceUseDefaultBackLink?: boolean
   }
   customContent?: (elements: {
-    logoLink: JSX.Element
-    authComponent: JSX.Element
-    notificationBell: JSX.Element
-    backButton: JSX.Element
+    logoLink: ReactNode
+    authComponent: ReactNode
+    notificationBell: ReactNode
+    backButton: ReactNode
   }) => JSX.Element
 }
 
@@ -113,7 +121,8 @@ export default function Navbar({
     </div>
   )
 
-  const notificationBell = <NotificationBell />
+  const isInIframe = useIsInIframe()
+  const notificationBell = !isInIframe && <NotificationBell />
 
   return (
     <>

--- a/src/modules/chat/ChatPage/ChatPage.tsx
+++ b/src/modules/chat/ChatPage/ChatPage.tsx
@@ -34,7 +34,7 @@ import { replaceUrl } from '@/utils/window'
 import dynamic from 'next/dynamic'
 import { ImageProps } from 'next/image'
 import Router, { useRouter } from 'next/router'
-import { useEffect, useRef, useState } from 'react'
+import { ReactNode, useEffect, useRef, useState } from 'react'
 import urlJoin from 'url-join'
 
 const NetworkStatus = dynamic(() => import('@/components/NetworkStatus'), {
@@ -224,7 +224,7 @@ function NavbarChatInfo({
 }: {
   image: ImageProps['src']
   messageCount: number
-  backButton: JSX.Element
+  backButton: ReactNode
   chatMetadata?: ChatMetadata
   chatId: string
 }) {

--- a/src/modules/chat/HubPage/HubPageNavbar.tsx
+++ b/src/modules/chat/HubPage/HubPageNavbar.tsx
@@ -7,13 +7,13 @@ import NavbarWithSearch, {
 import useIsInIframe from '@/hooks/useIsInIframe'
 import { getSpaceQuery } from '@/services/subsocial/spaces'
 import { getHubIds } from '@/utils/env/client'
-import { useState } from 'react'
+import { ReactNode, useState } from 'react'
 
 export type HubPageNavbarProps = {
-  logo: JSX.Element
-  auth: JSX.Element
-  backButton: JSX.Element
-  notificationBell: JSX.Element
+  logo: ReactNode
+  auth: ReactNode
+  backButton: ReactNode
+  notificationBell: ReactNode
   searchProps: NavbarWithSearchProps['searchProps']
   hubId: string
   chatsCount: number


### PR DESCRIPTION
Cause: back button in iframe is not using router.back because it needs to use replace.
so if user clicks on the bell and go to ann channel, the back will go to /x instead of prev url