### PR TITLE
Fix Timeout For Nonce

### DIFF
--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -30,7 +30,7 @@ export default function AccountPage() {
       routeReplace.current(returnUrl)
     })
     sendEvent('login', { eventSource: 'share_session_link' })
-  }, [login, isInitialized])
+  }, [login, isInitialized, sendEvent])
 
   return <DefaultLayout />
 }

--- a/src/pages/api/version.ts
+++ b/src/pages/api/version.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-const VERSION = '5'
+const VERSION = '6'
 
 export default function handler(_: NextApiRequest, res: NextApiResponse) {
   res.status(200).json(VERSION)


### PR DESCRIPTION
Currently, timeout for nonce is not working, because the `throw new Error(...)` inside of the setTimeout won't be rejecting the async function call