### PR TITLE
Fix box shadow not working in safari

### DIFF
--- a/src/components/extensions/donate/DonateModal/AmountInput.tsx
+++ b/src/components/extensions/donate/DonateModal/AmountInput.tsx
@@ -83,7 +83,7 @@ const AmountInput = ({
         )}
         type='number'
         className={cx(
-          'h-[54px] pr-16 text-base leading-6 ring-1 ring-inset ring-gray-500',
+          'h-[54px] appearance-none pr-16 text-base leading-6 ring-1 ring-inset ring-gray-500',
           'focus:outline-none focus:ring-1 focus:ring-gray-400',
           'hover:outline-none hover:ring-1 hover:ring-gray-400',
           'focus-visible:!ring-1 focus-visible:ring-gray-400',

--- a/src/components/inputs/SelectInput.tsx
+++ b/src/components/inputs/SelectInput.tsx
@@ -48,7 +48,7 @@ export default function SelectInput<AdditionalData = {}>({
                   'relative w-full cursor-default rounded-2xl',
                   selected?.icon ? 'py-2' : 'py-3',
                   'pl-4 pr-12 text-left',
-                  'text-base leading-6 ring-1 ring-inset ring-border-gray',
+                  'appearance-none text-base leading-6 ring-1 ring-inset ring-border-gray',
                   'bg-background text-text',
                   interactionRingStyles()
                 )}

--- a/src/components/inputs/common/FieldWrapper.tsx
+++ b/src/components/inputs/common/FieldWrapper.tsx
@@ -6,8 +6,9 @@ const inputStyles = cva('', {
   variants: {
     variant: {
       fill: 'bg-background-light',
-      'fill-bg': 'bg-background ring-1 ring-border-gray',
-      outlined: 'ring-1 ring-background-lightest bg-transparent',
+      'fill-bg': 'bg-background ring-1 ring-border-gray appearance-none',
+      outlined:
+        'ring-1 ring-background-lightest appearance-none bg-transparent',
     },
     pill: {
       true: 'rounded-3xl',


### PR DESCRIPTION
Box shadow in input (as a border replacement) was not working in safari

need to add
-webkit-appearance: none for it to work