### PR TITLE
Fix performance issue in grill

### DIFF
--- a/src/components/auth/ProfileModal/ProfileModal.tsx
+++ b/src/components/auth/ProfileModal/ProfileModal.tsx
@@ -42,7 +42,12 @@ export default function ProfileModal({
   ...props
 }: ProfileModalProps) {
   // Prefetch telegram linked account data
-  getLinkedTelegramAccountsQuery.useQuery({ address })
+  getLinkedTelegramAccountsQuery.useQuery(
+    { address },
+    {
+      enabled: props.isOpen,
+    }
+  )
   const [currentState, setCurrentState] = useState<ModalState>(
     step || 'account'
   )

--- a/src/components/chats/ChatItem/ChatItemMenus.tsx
+++ b/src/components/chats/ChatItem/ChatItemMenus.tsx
@@ -117,36 +117,7 @@ export default function ChatItemMenus({
 
     const showDonateMenuItem = messageOwnerEvmAddress && canSendMessage
 
-    return [
-      ...(canSendMessage ? [replyItem] : []),
-      ...(pinUnpinMenu ? [pinUnpinMenu] : []),
-      ...(showDonateMenuItem ? [donateMenuItem] : []),
-      ...(isAuthorized
-        ? [
-            {
-              icon: LuShield,
-              text: 'Moderate',
-              onClick: () => {
-                sendEvent('open_moderate_action_modal', { hubId, chatId })
-                setModalState('moderate')
-              },
-            },
-          ]
-        : []),
-      ...(address && canUsePromoExtensionAccounts.includes(address)
-        ? [
-            {
-              text: 'Secret Box',
-              icon: BiGift,
-              onClick: () => {
-                openExtensionModal('subsocial-decoded-promo', {
-                  recipient: ownerId ?? '',
-                  messageId,
-                })
-              },
-            },
-          ]
-        : []),
+    const menus: FloatingMenusProps['menus'] = [
       {
         text: 'Copy Text',
         icon: MdContentCopy,
@@ -177,6 +148,35 @@ export default function ChatItemMenus({
         onClick: () => setModalState('metadata'),
       },
     ]
+
+    if (address && canUsePromoExtensionAccounts.includes(address)) {
+      menus.unshift({
+        text: 'Secret Box',
+        icon: BiGift,
+        onClick: () => {
+          openExtensionModal('subsocial-decoded-promo', {
+            recipient: ownerId ?? '',
+            messageId,
+          })
+        },
+      })
+    }
+    if (isAuthorized) {
+      menus.unshift({
+        icon: LuShield,
+        text: 'Moderate',
+        onClick: () => {
+          sendEvent('open_moderate_action_modal', { hubId, chatId })
+          setModalState('moderate')
+        },
+      })
+    }
+
+    if (showDonateMenuItem) menus.unshift(donateMenuItem)
+    if (pinUnpinMenu) menus.unshift(pinUnpinMenu)
+    if (canSendMessage) menus.unshift(replyItem)
+
+    return menus
   }
   const menus = enableChatMenu && isSent ? getChatMenus() : []
 

--- a/src/components/chats/ChatList/CenterChatNotice.tsx
+++ b/src/components/chats/ChatList/CenterChatNotice.tsx
@@ -1,0 +1,52 @@
+import LinkText from '@/components/LinkText'
+import { cx } from '@/utils/class-names'
+import { ComponentProps } from 'react'
+
+export default function CenterChatNotice({
+  isMyChat,
+  ...props
+}: ComponentProps<'div'> & { isMyChat: boolean }) {
+  return (
+    <div
+      {...props}
+      className={cx(
+        'flex flex-col rounded-2xl bg-background-light/50 px-6 py-4 text-sm text-text-muted',
+        props.className
+      )}
+    >
+      {isMyChat ? (
+        <>
+          <div>
+            <span>You have created a public group chat, which is:</span>
+            <div className='pl-4'>
+              <ul className='mb-1 list-disc whitespace-nowrap pl-2'>
+                <li>Persistent & on-chain</li>
+                <li>Censorship resistant</li>
+                <li>
+                  Powered by{' '}
+                  <LinkText
+                    href='https://subsocial.network'
+                    openInNewTab
+                    variant='primary'
+                  >
+                    Subsocial
+                  </LinkText>
+                </li>
+              </ul>
+            </div>
+
+            <span>You can:</span>
+            <div className='pl-4'>
+              <ul className='list-disc whitespace-nowrap pl-2'>
+                <li>Moderate content and users</li>
+                <li>Hide the chat from others on Grill</li>
+              </ul>
+            </div>
+          </div>
+        </>
+      ) : (
+        <span>No messages here yet</span>
+      )}
+    </div>
+  )
+}

--- a/src/components/chats/ChatList/ChatItemWithMenu.tsx
+++ b/src/components/chats/ChatList/ChatItemWithMenu.tsx
@@ -7,7 +7,7 @@ import { ScrollToMessage } from './hooks/useScrollToMessage'
 
 const MemoizedChatItemContainer = memo(ChatItemContainer)
 
-export type ChatItemWrapperProps = {
+export type ChatItemWithMenuProps = {
   message: PostData | null | undefined
   isBottomMessage: boolean
   chatId: string
@@ -15,14 +15,14 @@ export type ChatItemWrapperProps = {
   lastReadId: string | null | undefined
   scrollToMessage: ScrollToMessage
 }
-function ChatItemWrapper({
+function ChatItemWithMenu({
   message,
   isBottomMessage,
   chatId,
   hubId,
   lastReadId,
   scrollToMessage,
-}: ChatItemWrapperProps) {
+}: ChatItemWithMenuProps) {
   const isLastReadMessage = lastReadId === message?.id
   const showLastUnreadMessageNotice = isLastReadMessage && !isBottomMessage
 
@@ -67,5 +67,5 @@ function ChatItemWrapper({
     </Fragment>
   )
 }
-const MemoizedChatItemWrapper = memo(ChatItemWrapper)
+const MemoizedChatItemWrapper = memo(ChatItemWithMenu)
 export default MemoizedChatItemWrapper

--- a/src/components/chats/ChatList/ChatItemWrapper.tsx
+++ b/src/components/chats/ChatList/ChatItemWrapper.tsx
@@ -1,0 +1,71 @@
+import { PostData } from '@subsocial/api/types'
+import { Fragment, memo } from 'react'
+import ChatItemMenus from '../ChatItem/ChatItemMenus'
+import { getMessageElementId } from '../utils'
+import ChatItemContainer from './ChatItemContainer'
+import { ScrollToMessage } from './hooks/useScrollToMessage'
+
+const MemoizedChatItemContainer = memo(ChatItemContainer)
+
+export type ChatItemWrapperProps = {
+  message: PostData | null | undefined
+  isBottomMessage: boolean
+  chatId: string
+  hubId: string
+  lastReadId: string | null | undefined
+  scrollToMessage: ScrollToMessage
+}
+function ChatItemWrapper({
+  message,
+  isBottomMessage,
+  chatId,
+  hubId,
+  lastReadId,
+  scrollToMessage,
+}: ChatItemWrapperProps) {
+  const isLastReadMessage = lastReadId === message?.id
+  const showLastUnreadMessageNotice = isLastReadMessage && !isBottomMessage
+
+  const chatElement = message ? (
+    <ChatItemMenus
+      chatId={chatId}
+      messageId={message.id}
+      key={message.id}
+      hubId={hubId}
+    >
+      {(config) => {
+        const { referenceProps, toggleDisplay } = config || {}
+        return (
+          <div
+            {...referenceProps}
+            onContextMenu={(e) => {
+              e.preventDefault()
+              toggleDisplay?.(e)
+            }}
+          >
+            <MemoizedChatItemContainer
+              enableChatMenu={false}
+              hubId={hubId}
+              chatId={chatId}
+              message={message}
+              messageBubbleId={getMessageElementId(message.id)}
+              scrollToMessage={scrollToMessage}
+            />
+          </div>
+        )
+      }}
+    </ChatItemMenus>
+  ) : null
+  if (!showLastUnreadMessageNotice) return chatElement
+
+  return (
+    <Fragment>
+      <div className='my-2 w-full rounded-md bg-background-light py-0.5 text-center text-sm'>
+        Unread messages
+      </div>
+      {chatElement}
+    </Fragment>
+  )
+}
+const MemoizedChatItemWrapper = memo(ChatItemWrapper)
+export default MemoizedChatItemWrapper

--- a/src/components/chats/ChatList/ChatList.tsx
+++ b/src/components/chats/ChatList/ChatList.tsx
@@ -19,7 +19,6 @@ import { replaceUrl, sendMessageToParentWindow } from '@/utils/window'
 import { useRouter } from 'next/router'
 import {
   ComponentProps,
-  Fragment,
   useEffect,
   useId,
   useMemo,
@@ -28,10 +27,8 @@ import {
 } from 'react'
 import InfiniteScroll from 'react-infinite-scroll-component'
 import urlJoin from 'url-join'
-import ChatItemMenus from '../ChatItem/ChatItemMenus'
-import { getMessageElementId } from '../utils'
 import CenterChatNotice from './CenterChatNotice'
-import ChatItemContainer from './ChatItemContainer'
+import MemoizedChatItemWrapper from './ChatItemWrapper'
 import ChatLoading from './ChatLoading'
 import ChatTopNotice from './ChatTopNotice'
 import useFocusedLastMessageId from './hooks/useFocusedLastMessageId'
@@ -254,48 +251,18 @@ function ChatListContent({
             scrollThreshold={`${SCROLL_THRESHOLD}px`}
           >
             {messageQueries.map(({ data: message }, index) => {
-              const isLastReadMessage = lastReadId === message?.id
               // bottom message is the first element, because the flex direction is reversed
               const isBottomMessage = index === 0
-              const showLastUnreadMessageNotice =
-                isLastReadMessage && !isBottomMessage
-
-              const chatElement = message && (
-                <ChatItemMenus
-                  chatId={chatId}
-                  messageId={message.id}
-                  key={message.id}
-                  hubId={hubId}
-                >
-                  {(config) => {
-                    const { referenceProps, toggleDisplay } = config || {}
-                    return (
-                      <ChatItemContainer
-                        {...referenceProps}
-                        onContextMenu={(e) => {
-                          e.preventDefault()
-                          toggleDisplay?.(e)
-                        }}
-                        enableChatMenu={false}
-                        hubId={hubId}
-                        chatId={chatId}
-                        message={message}
-                        messageBubbleId={getMessageElementId(message.id)}
-                        scrollToMessage={scrollToMessage}
-                      />
-                    )
-                  }}
-                </ChatItemMenus>
-              )
-              if (!showLastUnreadMessageNotice) return chatElement
-
               return (
-                <Fragment key={message?.id || index}>
-                  <div className='my-2 w-full rounded-md bg-background-light py-0.5 text-center text-sm'>
-                    Unread messages
-                  </div>
-                  {chatElement}
-                </Fragment>
+                <MemoizedChatItemWrapper
+                  key={message?.id ?? index}
+                  chatId={chatId}
+                  hubId={hubId}
+                  isBottomMessage={isBottomMessage}
+                  message={message}
+                  scrollToMessage={scrollToMessage}
+                  lastReadId={lastReadId}
+                />
               )
             })}
           </InfiniteScroll>

--- a/src/components/chats/ChatList/ChatList.tsx
+++ b/src/components/chats/ChatList/ChatList.tsx
@@ -44,7 +44,8 @@ export default function ChatList(props: ChatListProps) {
   return <ChatListContent key={props.chatId} {...props} />
 }
 
-const SCROLL_THRESHOLD = 1000
+// If using any threshold, the scroll will be janky
+const SCROLL_THRESHOLD = 0
 
 function ChatListContent({
   asContainer,

--- a/src/components/chats/ChatList/ChatListSupportingContent.tsx
+++ b/src/components/chats/ChatList/ChatListSupportingContent.tsx
@@ -1,0 +1,163 @@
+import Container from '@/components/Container'
+import MessageModal from '@/components/modals/MessageModal'
+import useLastReadMessageId from '@/hooks/useLastReadMessageId'
+import usePrevious from '@/hooks/usePrevious'
+import useWrapInRef from '@/hooks/useWrapInRef'
+import { getPostQuery } from '@/services/api/query'
+import { useMessageData } from '@/stores/message'
+import { cx } from '@/utils/class-names'
+import { getChatPageLink, getUrlQuery } from '@/utils/links'
+import { validateNumber } from '@/utils/strings'
+import { replaceUrl, sendMessageToParentWindow } from '@/utils/window'
+import { useRouter } from 'next/router'
+import { useEffect, useRef, useState } from 'react'
+import urlJoin from 'url-join'
+import { ChatListProps } from './ChatList'
+import useFocusedLastMessageId from './hooks/useFocusedLastMessageId'
+import useIsAtBottom from './hooks/useIsAtBottom'
+import { ScrollToMessage } from './hooks/useScrollToMessage'
+import { NewMessageNotice } from './NewMessageNotice'
+
+export type ChatListSupportingContentProps = Pick<
+  ChatListProps,
+  'hubId' | 'chatId' | 'asContainer' | 'newMessageNoticeClassName'
+> & {
+  scrollToMessage: ScrollToMessage
+  loadedMessageQueries: ReturnType<typeof getPostQuery.useQueries>
+  rawMessageIds: string[] | undefined | null
+  filteredMessageIds: string[]
+  scrollContainerRef: React.RefObject<HTMLDivElement>
+}
+export default function ChatListSupportingContent({
+  hubId,
+  chatId,
+  scrollToMessage,
+  asContainer,
+  newMessageNoticeClassName,
+  scrollContainerRef,
+  loadedMessageQueries,
+  rawMessageIds,
+  filteredMessageIds,
+}: ChatListSupportingContentProps) {
+  const router = useRouter()
+
+  const [initialNewMessageCount, setInitialNewMessageCount] = useState(0)
+  const lastReadId = useFocusedLastMessageId(chatId)
+  const [recipient, setRecipient] = useState('')
+  const [messageModalMsgId, setMessageModalMsgId] = useState('')
+  const prevMessageModalMsgId = usePrevious(messageModalMsgId)
+
+  const Component = asContainer ? Container<'div'> : 'div'
+
+  // TODO: refactor this by putting the url query getter logic to ChatPage
+  const hasScrolledToMessageRef = useRef(false)
+  const filteredMessageIdsRef = useWrapInRef(filteredMessageIds)
+  useEffect(() => {
+    if (hasScrolledToMessageRef.current) return
+    hasScrolledToMessageRef.current = true
+
+    const messageId = getUrlQuery('messageId')
+    const recipient = getUrlQuery('targetAcc')
+    const isMessageIdsFetched = rawMessageIds !== undefined
+
+    if (!isMessageIdsFetched) return
+
+    if (!messageId || !validateNumber(messageId)) {
+      if (lastReadId) {
+        scrollToMessage(lastReadId ?? '', {
+          shouldHighlight: false,
+          smooth: false,
+        }).then(() => {
+          const lastReadIdIndex = filteredMessageIdsRef.current.findIndex(
+            (id) => id === lastReadId
+          )
+          const newMessageCount =
+            lastReadIdIndex === -1
+              ? 0
+              : filteredMessageIdsRef.current.length - lastReadIdIndex - 1
+
+          sendMessageToParentWindow(
+            'unread',
+            (filteredMessageIds.length ?? 0).toString()
+          )
+
+          setInitialNewMessageCount(newMessageCount)
+        })
+      }
+      return
+    }
+
+    setMessageModalMsgId(messageId)
+    setRecipient(recipient)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rawMessageIds, filteredMessageIdsRef, hasScrolledToMessageRef])
+
+  const { setLastReadMessageId } = useLastReadMessageId(chatId)
+  useEffect(() => {
+    const lastId = rawMessageIds?.[rawMessageIds.length - 1]
+    if (!lastId) return
+    setLastReadMessageId(lastId)
+  }, [setLastReadMessageId, rawMessageIds])
+
+  useEffect(() => {
+    if (messageModalMsgId) {
+      replaceUrl(urlJoin(getChatPageLink(router), `/${messageModalMsgId}`))
+    } else if (prevMessageModalMsgId && !messageModalMsgId) {
+      replaceUrl(getChatPageLink(router))
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prevMessageModalMsgId, messageModalMsgId])
+
+  return (
+    <>
+      <MessageModal
+        hubId={hubId}
+        isOpen={!!messageModalMsgId}
+        closeModal={() => setMessageModalMsgId('')}
+        messageId={messageModalMsgId}
+        scrollToMessage={scrollToMessage}
+        recipient={recipient}
+      />
+      <Component>
+        <div className='relative'>
+          <NewMessageNotice
+            key={initialNewMessageCount}
+            className={cx(
+              'absolute bottom-2 right-3',
+              newMessageNoticeClassName
+            )}
+            initialNewMessageCount={initialNewMessageCount}
+            messageIds={rawMessageIds ?? []}
+            scrollContainerRef={scrollContainerRef}
+          />
+        </div>
+      </Component>
+      <ScrollToBottom
+        loadedMessageLength={loadedMessageQueries.length}
+        scrollContainerRef={scrollContainerRef}
+      />
+    </>
+  )
+}
+
+function ScrollToBottom({
+  scrollContainerRef,
+  loadedMessageLength,
+}: {
+  scrollContainerRef: React.RefObject<HTMLDivElement>
+  loadedMessageLength: number
+}) {
+  const isAtBottom = useIsAtBottom(scrollContainerRef, 100)
+  const replyTo = useMessageData((state) => state.replyTo)
+
+  const isAtBottomRef = useWrapInRef(isAtBottom)
+  useEffect(() => {
+    if (!isAtBottomRef.current) return
+    scrollContainerRef.current?.scrollTo({
+      top: scrollContainerRef.current?.scrollHeight,
+      behavior: 'auto',
+    })
+  }, [loadedMessageLength, isAtBottomRef, scrollContainerRef, replyTo])
+
+  return null
+}

--- a/src/components/chats/ChatList/ChatListSupportingContent.tsx
+++ b/src/components/chats/ChatList/ChatListSupportingContent.tsx
@@ -3,7 +3,6 @@ import MessageModal from '@/components/modals/MessageModal'
 import useLastReadMessageId from '@/hooks/useLastReadMessageId'
 import usePrevious from '@/hooks/usePrevious'
 import useWrapInRef from '@/hooks/useWrapInRef'
-import { getPostQuery } from '@/services/api/query'
 import { useMessageData } from '@/stores/message'
 import { cx } from '@/utils/class-names'
 import { getChatPageLink, getUrlQuery } from '@/utils/links'
@@ -23,7 +22,7 @@ export type ChatListSupportingContentProps = Pick<
   'hubId' | 'chatId' | 'asContainer' | 'newMessageNoticeClassName'
 > & {
   scrollToMessage: ScrollToMessage
-  loadedMessageQueries: ReturnType<typeof getPostQuery.useQueries>
+  renderedMessageLength: number
   rawMessageIds: string[] | undefined | null
   filteredMessageIds: string[]
   scrollContainerRef: React.RefObject<HTMLDivElement>
@@ -35,7 +34,7 @@ export default function ChatListSupportingContent({
   asContainer,
   newMessageNoticeClassName,
   scrollContainerRef,
-  loadedMessageQueries,
+  renderedMessageLength,
   rawMessageIds,
   filteredMessageIds,
 }: ChatListSupportingContentProps) {
@@ -133,7 +132,7 @@ export default function ChatListSupportingContent({
         </div>
       </Component>
       <ScrollToBottom
-        loadedMessageLength={loadedMessageQueries.length}
+        renderedMessageLength={renderedMessageLength}
         scrollContainerRef={scrollContainerRef}
       />
     </>
@@ -142,10 +141,10 @@ export default function ChatListSupportingContent({
 
 function ScrollToBottom({
   scrollContainerRef,
-  loadedMessageLength,
+  renderedMessageLength,
 }: {
   scrollContainerRef: React.RefObject<HTMLDivElement>
-  loadedMessageLength: number
+  renderedMessageLength: number
 }) {
   const isAtBottom = useIsAtBottom(scrollContainerRef, 100)
   const replyTo = useMessageData((state) => state.replyTo)
@@ -157,7 +156,7 @@ function ScrollToBottom({
       top: scrollContainerRef.current?.scrollHeight,
       behavior: 'auto',
     })
-  }, [loadedMessageLength, isAtBottomRef, scrollContainerRef, replyTo])
+  }, [renderedMessageLength, isAtBottomRef, scrollContainerRef, replyTo])
 
   return null
 }

--- a/src/components/chats/ChatList/NewMessageNotice.tsx
+++ b/src/components/chats/ChatList/NewMessageNotice.tsx
@@ -23,7 +23,7 @@ export function NewMessageNotice({
 }: NewMessageNoticeProps) {
   const isAtBottom = useIsAtBottom(scrollContainerRef, IS_AT_BOTTOM_OFFSET)
   const { anyNewData, clearAnyNewData } = useAnyNewData(
-    messageIds,
+    messageIds.length,
     initialNewMessageCount
   )
 

--- a/src/components/chats/ChatList/PinnedMessage.tsx
+++ b/src/components/chats/ChatList/PinnedMessage.tsx
@@ -1,0 +1,57 @@
+import PinIcon from '@/assets/icons/pin.png'
+import Container from '@/components/Container'
+import { getPostExtension } from '@/components/extensions/utils'
+import { getPinnedMessageInChatId } from '@/constants/chat'
+import { getPostQuery } from '@/services/api/query'
+import Image from 'next/image'
+import useScrollToMessage from './hooks/useScrollToMessage'
+
+type PinnedMessageProps = {
+  chatId: string
+  asContainer?: boolean
+  scrollToMessage: ReturnType<typeof useScrollToMessage>
+}
+export default function PinnedMessage({
+  chatId,
+  asContainer,
+  scrollToMessage,
+}: PinnedMessageProps) {
+  const { data: chat } = getPostQuery.useQuery(chatId)
+  const pinExtension = getPostExtension(
+    chat?.content?.extensions,
+    'subsocial-pinned-posts'
+  )
+
+  const pinnedMessage =
+    getPinnedMessageInChatId(chatId) || pinExtension?.properties.ids[0]
+  const { data: message } = getPostQuery.useQuery(pinnedMessage ?? '', {
+    enabled: !!pinnedMessage,
+  })
+  if (!message) return null
+
+  const Component = asContainer ? Container<'div'> : 'div'
+  return (
+    <div className='sticky top-0 z-10 border-b border-border-gray bg-background-light text-sm'>
+      <Component
+        className='flex cursor-pointer items-center gap-4 overflow-hidden py-2'
+        onClick={() => scrollToMessage(message.id)}
+      >
+        <div className='mr-0.5 flex-shrink-0'>
+          <Image
+            src={PinIcon}
+            alt='pin'
+            width={16}
+            height={16}
+            className='ml-3 h-4 w-4'
+          />
+        </div>
+        <div className='flex flex-col overflow-hidden'>
+          <span className='font-medium text-text-primary'>Pinned Message</span>
+          <span className='overflow-hidden text-ellipsis whitespace-nowrap'>
+            {message.content?.body}
+          </span>
+        </div>
+      </Component>
+    </div>
+  )
+}

--- a/src/components/chats/ChatList/hooks/useAnyNewData.ts
+++ b/src/components/chats/ChatList/hooks/useAnyNewData.ts
@@ -2,16 +2,16 @@ import usePrevious from '@/hooks/usePrevious'
 import { useCallback, useEffect, useState } from 'react'
 
 export default function useAnyNewData(
-  data: unknown[],
+  dataLength: number,
   initialNewMessageCount?: number
 ) {
   const [anyNewData, setAnyNewData] = useState(initialNewMessageCount ?? 0)
-  const previousDataLength = usePrevious(data.length)
+  const previousDataLength = usePrevious(dataLength)
 
   useEffect(() => {
-    const newDataLength = data.length - (previousDataLength ?? data.length)
+    const newDataLength = dataLength - (previousDataLength ?? dataLength)
     if (newDataLength > 0) setAnyNewData((prev) => prev + newDataLength)
-  }, [previousDataLength, data])
+  }, [previousDataLength, dataLength])
 
   const clearAnyNewData = useCallback(() => setAnyNewData(0), [])
 

--- a/src/components/chats/ChatList/hooks/useScrollToMessage.ts
+++ b/src/components/chats/ChatList/hooks/useScrollToMessage.ts
@@ -1,3 +1,5 @@
+import useWrapInRef from '@/hooks/useWrapInRef'
+import { useCallback } from 'react'
 import {
   scrollToMessageElement,
   ScrollToMessageElementConfig,
@@ -12,12 +14,16 @@ export default function useScrollToMessage(
 ) {
   const getElement = useGetMessageElement(getMessageElementArgs)
 
-  return async (chatId: string, config?: ScrollToMessageElementConfig) => {
-    const element = await getElement(chatId)
-    if (!element) return
+  const loadMoreControllerRef = useWrapInRef(loadMoreController)
+  return useCallback(
+    async (chatId: string, config?: ScrollToMessageElementConfig) => {
+      const element = await getElement(chatId)
+      if (!element) return
 
-    loadMoreController.pause()
-    await scrollToMessageElement(element, scrollContainerRef.current, config)
-    loadMoreController.unpause()
-  }
+      loadMoreControllerRef.current.pause()
+      await scrollToMessageElement(element, scrollContainerRef.current, config)
+      loadMoreControllerRef.current.unpause()
+    },
+    [getElement, loadMoreControllerRef, scrollContainerRef]
+  )
 }

--- a/src/components/chats/ChatRoom/ChatRoom.tsx
+++ b/src/components/chats/ChatRoom/ChatRoom.tsx
@@ -10,7 +10,7 @@ import { useSendEvent } from '@/stores/analytics'
 import { useMessageData } from '@/stores/message'
 import { cx } from '@/utils/class-names'
 import dynamic from 'next/dynamic'
-import { ComponentProps, useEffect, useRef } from 'react'
+import { ComponentProps, RefObject, useEffect, useRef } from 'react'
 import ChatInputBar from './ChatInputBar'
 
 const ChatList = dynamic(() => import('../ChatList/ChatList'), {
@@ -35,6 +35,41 @@ export default function ChatRoom({
   hubId,
   ...props
 }: ChatRoomProps) {
+  const replyTo = useMessageData((state) => state.replyTo)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+
+  return (
+    <div {...props} className={cx('flex flex-col', className)}>
+      <ChatList
+        hubId={hubId}
+        newMessageNoticeClassName={cx(replyTo && 'bottom-2')}
+        chatId={chatId}
+        asContainer={asContainer}
+        scrollableContainerClassName={scrollableContainerClassName}
+        scrollContainerRef={scrollContainerRef}
+      />
+      <ChatInputWrapper
+        chatId={chatId}
+        hubId={hubId}
+        asContainer={asContainer}
+        scrollContainerRef={scrollContainerRef}
+      />
+    </div>
+  )
+}
+
+type ChatInputWrapperProps = Pick<
+  ChatRoomProps,
+  'asContainer' | 'chatId' | 'hubId'
+> & {
+  scrollContainerRef: RefObject<HTMLDivElement>
+}
+function ChatInputWrapper({
+  asContainer,
+  chatId,
+  hubId,
+  scrollContainerRef,
+}: ChatInputWrapperProps) {
   const clearReplyTo = useMessageData((state) => state.clearReplyTo)
   const replyTo = useMessageData((state) => state.replyTo)
   const sendEvent = useSendEvent()
@@ -47,7 +82,6 @@ export default function ChatRoom({
   )
 
   const Component = asContainer ? Container<'div'> : 'div'
-  const scrollContainerRef = useRef<HTMLDivElement>(null)
 
   const scrollToBottom = () => {
     const scrollContainer = scrollContainerRef.current
@@ -68,15 +102,7 @@ export default function ChatRoom({
   const isHidden = chat?.struct.hidden
 
   return (
-    <div {...props} className={cx('flex flex-col', className)}>
-      <ChatList
-        hubId={hubId}
-        newMessageNoticeClassName={cx(replyTo && 'bottom-2')}
-        chatId={chatId}
-        asContainer={asContainer}
-        scrollableContainerClassName={scrollableContainerClassName}
-        scrollContainerRef={scrollContainerRef}
-      />
+    <>
       <Component
         className={cx('mt-auto flex flex-col py-2', replyTo && 'pt-0')}
       >
@@ -144,6 +170,6 @@ export default function ChatRoom({
       </Component>
 
       <ExtensionModals chatId={chatId} onSubmit={scrollToBottom} />
-    </div>
+    </>
   )
 }

--- a/src/components/chats/ChatRoom/ChatRoom.tsx
+++ b/src/components/chats/ChatRoom/ChatRoom.tsx
@@ -76,7 +76,6 @@ export default function ChatRoom({
         asContainer={asContainer}
         scrollableContainerClassName={scrollableContainerClassName}
         scrollContainerRef={scrollContainerRef}
-        replyTo={replyTo}
       />
       <Component
         className={cx('mt-auto flex flex-col py-2', replyTo && 'pt-0')}

--- a/src/hooks/useIsMessageBlocked.ts
+++ b/src/hooks/useIsMessageBlocked.ts
@@ -3,15 +3,20 @@ import { isMessageBlocked } from '@/utils/chat'
 import { PostData } from '@subsocial/api/types'
 import { useMemo } from 'react'
 
-const cachedBlockedMap = new Map<readonly [any, any], Set<string>>()
+const cachedBlockedMap = new Map<any, Map<any, Set<string>>>()
 function getBlockedSet(ids1: string[] | undefined, ids2: string[] | undefined) {
-  const key = [ids1, ids2] as const
-  if (cachedBlockedMap.has(key)) {
-    return cachedBlockedMap.get(key)!
+  if (cachedBlockedMap.has(ids1)) {
+    const cachedMap = cachedBlockedMap.get(ids1)!
+    if (cachedMap.has(ids2)) {
+      return cachedMap.get(ids2)!
+    }
   }
 
   const set = new Set([...(ids1 ?? []), ...(ids2 ?? [])])
-  cachedBlockedMap.set(key, set)
+  if (!cachedBlockedMap.has(ids1)) {
+    cachedBlockedMap.set(ids1, new Map())
+  }
+  cachedBlockedMap.get(ids1)!.set(ids2, set)
 
   return set
 }

--- a/src/hooks/useIsMessageBlocked.ts
+++ b/src/hooks/useIsMessageBlocked.ts
@@ -3,6 +3,19 @@ import { isMessageBlocked } from '@/utils/chat'
 import { PostData } from '@subsocial/api/types'
 import { useMemo } from 'react'
 
+const cachedBlockedMap = new Map<readonly [any, any], Set<string>>()
+function getBlockedSet(ids1: string[] | undefined, ids2: string[] | undefined) {
+  const key = [ids1, ids2] as const
+  if (cachedBlockedMap.has(key)) {
+    return cachedBlockedMap.get(key)!
+  }
+
+  const set = new Set([...(ids1 ?? []), ...(ids2 ?? [])])
+  cachedBlockedMap.set(key, set)
+
+  return set
+}
+
 export default function useIsMessageBlocked(
   hubId: string,
   message: PostData | null | undefined,
@@ -21,27 +34,17 @@ export default function useIsMessageBlocked(
   const blockedInHub = hubModerationData?.blockedResources
   const blockedInChat = chatModerationData?.blockedResources
 
-  const blockedIdsSet = useMemo(
-    () =>
-      new Set([
-        ...(blockedInHub?.postId ?? []),
-        ...(blockedInChat?.postId ?? []),
-      ]),
-    [blockedInHub, blockedInChat]
-  )
-  const blockedCidsSet = useMemo(
-    () =>
-      new Set([...(blockedInHub?.cid ?? []), ...(blockedInChat?.cid ?? [])]),
-    [blockedInHub, blockedInChat]
-  )
-  const blockedAddressesSet = useMemo(
-    () =>
-      new Set([
-        ...(blockedInHub?.address ?? []),
-        ...(blockedInChat?.address ?? []),
-      ]),
-    [blockedInHub, blockedInChat]
-  )
+  const blockedIdsSet = useMemo(() => {
+    return getBlockedSet(blockedInHub?.postId, blockedInChat?.postId)
+  }, [blockedInHub, blockedInChat])
+
+  const blockedCidsSet = useMemo(() => {
+    return getBlockedSet(blockedInHub?.cid, blockedInChat?.cid)
+  }, [blockedInHub, blockedInChat])
+
+  const blockedAddressesSet = useMemo(() => {
+    return getBlockedSet(blockedInHub?.address, blockedInChat?.address)
+  }, [blockedInHub, blockedInChat])
 
   return isMessageBlocked(message, {
     postIds: blockedIdsSet,

--- a/src/stores/my-account.ts
+++ b/src/stores/my-account.ts
@@ -71,23 +71,28 @@ const sendLaunchEvent = async (address?: string | false) => {
   if (!address) {
     sendEvent('launch_app', undefined, userProperties)
   } else {
-    const linkedTgAccData = await getLinkedTelegramAccountsQuery.fetchQuery(
-      queryClient,
-      {
-        address,
-      }
-    )
-    userProperties.tgNotifsConnected = (linkedTgAccData?.length || 0) > 0
+    try {
+      const linkedTgAccData = await getLinkedTelegramAccountsQuery.fetchQuery(
+        queryClient,
+        {
+          address,
+        }
+      )
+      userProperties.tgNotifsConnected = (linkedTgAccData?.length || 0) > 0
+    } catch {}
 
-    const [evmLinkedAddress] = await getAccountsData([address])
+    try {
+      const [evmLinkedAddress] = await getAccountsData([address])
+      userProperties.evmLinked = !!evmLinkedAddress
+    } catch {}
 
-    userProperties.evmLinked = !!evmLinkedAddress
-
-    const ownedPostIds = await getOwnedPostIdsQuery.fetchQuery(
-      queryClient,
-      address
-    )
-    userProperties.ownedChat = (ownedPostIds?.length || 0) > 0
+    try {
+      const ownedPostIds = await getOwnedPostIdsQuery.fetchQuery(
+        queryClient,
+        address
+      )
+      userProperties.ownedChat = (ownedPostIds?.length || 0) > 0
+    } catch {}
 
     userProperties.webNotifsEnabled = isWebNotificationsEnabled()
 


### PR DESCRIPTION
## Fixes
- Add memo in multiple places so not every chat is rerendered when new data are coming
- Move several states into independent component so if any of those state changes, chat list won't need to rerender
- Cache the conversion process from array of blocked ids to set because its used in all ChatItem and it's now done for every ChatItem
- Fix issue with load more:
  With prev impl, if any replied message are preloaded, the loadedMessageIds.length will change, making the infinite scroll thinks that the fetch already done, so it fetches again while user is still on the top of the page
- Remove scroll threshold because it will make the scrolling jumps around when new data is loaded