### PR TITLE
Add more analytic events

### DIFF
--- a/src/components/auth/CustomConnectButton.tsx
+++ b/src/components/auth/CustomConnectButton.tsx
@@ -102,11 +102,12 @@ export const CustomConnectButton = ({
         if (!connected) {
           return (
             <Button
-              onClick={() => {
+              {...commonButtonProps}
+              onClick={(e) => {
                 setHasInteractedOnce(true)
                 openConnectModal()
+                commonButtonProps.onClick?.(e as any)
               }}
-              {...commonButtonProps}
             >
               {usedLabel}
             </Button>
@@ -116,11 +117,12 @@ export const CustomConnectButton = ({
         if (chain.unsupported) {
           return (
             <Button
-              onClick={() => {
+              {...commonButtonProps}
+              onClick={(e) => {
                 setHasInteractedOnce(true)
                 openChainModal()
+                commonButtonProps.onClick?.(e as any)
               }}
-              {...commonButtonProps}
             >
               Wrong network
             </Button>

--- a/src/components/auth/LoginModal/LoginModalContent.tsx
+++ b/src/components/auth/LoginModal/LoginModalContent.tsx
@@ -158,6 +158,7 @@ export const EnterSecretKeyContent = ({
 }
 
 export const AccountCreatedContent = ({ setCurrentStep }: ContentProps) => {
+  const sendEvent = useSendEvent()
   const address = useMyAccount((state) => state.address)
 
   const { signAndLinkEvmAddress, isLoading } = useSignMessageAndLinkEvmAddress({
@@ -187,6 +188,9 @@ export const AccountCreatedContent = ({ setCurrentStep }: ContentProps) => {
         signAndLinkEvmAddress={signAndLinkEvmAddress}
         isLoading={isLoading}
         secondLabel='Sign Message'
+        onClick={() =>
+          sendEvent('click connect_wallet_button from account_created')
+        }
         label={
           <div className='flex items-center justify-center gap-2'>
             <WalletIcon />

--- a/src/components/chats/ChatList/hooks/useInfiniteScrollData.ts
+++ b/src/components/chats/ChatList/hooks/useInfiniteScrollData.ts
@@ -44,5 +44,5 @@ export default function useInfiniteScrollData<Data>(
     }
   }, [hasMore, isPausedLoadMore])
 
-  return { currentData, hasMore, loadMore }
+  return { currentData, hasMore, loadMore, currentPage }
 }

--- a/src/components/floating/PopOver.tsx
+++ b/src/components/floating/PopOver.tsx
@@ -57,6 +57,7 @@ export type PopOverProps = VariantProps<typeof panelStyles> & {
     isOpen: boolean
     setIsOpen: React.Dispatch<React.SetStateAction<boolean>>
   }
+  onClose?: () => void
   triggerOnHover?: boolean
   initialFocus?: Parameters<typeof FloatingFocusManager>[0]['initialFocus']
   popOverProps?: ComponentProps<'div'>
@@ -66,6 +67,7 @@ export default function PopOver({
   children,
   trigger,
   asButton = false,
+  onClose,
   withCloseButton,
   withArrow = true,
   placement = 'bottom',
@@ -169,6 +171,7 @@ export default function PopOver({
                   <Button
                     onClick={(e) => {
                       e.stopPropagation()
+                      onClose?.()
                       setIsOpen(false)
                     }}
                     className='my-1 ml-4 mr-0 p-0 text-2xl text-current'

--- a/src/components/navbar/Navbar/ProfileAvatar.tsx
+++ b/src/components/navbar/Navbar/ProfileAvatar.tsx
@@ -1,6 +1,7 @@
 import AddressAvatar from '@/components/AddressAvatar'
 import ProfileModal from '@/components/auth/ProfileModal'
 import PopOver from '@/components/floating/PopOver'
+import { useSendEvent } from '@/stores/analytics'
 import { cx } from '@/utils/class-names'
 import { getCurrentUrlWithoutQuery, getUrlQuery } from '@/utils/links'
 import { replaceUrl } from '@/utils/window'
@@ -23,6 +24,7 @@ export default function ProfileAvatar({
   const [directlyOpenEvmLinking, setDirectlyOpenEvmLinking] = useState(false)
 
   const [showNotif, setShowNotif] = useState(false)
+  const sendEvent = useSendEvent()
 
   useEffect(() => {
     if (popOverControl?.isOpen) {
@@ -71,8 +73,10 @@ export default function ProfileAvatar({
           withCloseButton
           trigger={null}
           initialFocus={-1}
+          onClose={() => sendEvent('close evm_linking_popover')}
           popOverProps={{
             onClick: () => {
+              sendEvent('click evm_linking_popover')
               setDirectlyOpenEvmLinking(true)
               setIsOpen(true)
             },

--- a/src/stores/analytics.ts
+++ b/src/stores/analytics.ts
@@ -1,6 +1,8 @@
 import { createUserId } from '@/services/api/mutation'
+import { getIdFromSlug } from '@/utils/slug'
 import { LocalStorage } from '@/utils/storage'
 import { type BaseEvent, type BrowserClient } from '@amplitude/analytics-types'
+import Router from 'next/router'
 import { useParentData } from './parent'
 import { create } from './utils'
 
@@ -78,10 +80,20 @@ export const useAnalytics = create<State & Actions>()((set, get) => {
       eventProperties?: EventProperties,
       userProperties?: UserProperties
     ) => {
+      // const { currentUrl } = useLocation.getState()
+      console.log(Router.query, Router.pathname, Router)
       const { amp, userId, deviceId } = get()
 
       const { parentOrigin } = useParentData.getState()
-      const commonProperties = { from: parentOrigin }
+
+      const slug = Router.query.slug as string
+      const chatId = slug && getIdFromSlug(slug)
+      const commonProperties = {
+        from: parentOrigin,
+        pathname: Router.asPath,
+        query: { ...Router.query, chatId },
+      }
+
       const mergedEventProperties = {
         ...commonProperties,
         ...eventProperties,


### PR DESCRIPTION
# Events
- event 'click connect_wallet_button from account_created' when clicking connect wallet button
- 'load_more_messages' when infinite scroll loads more data with props: `{ currentPage }`
- 'close evm_linking_popover' and 'click evm_linking_popover' for evm linking popover
- Add additional properties for every event with `pathname` and `query` based on router state, with example in image below
![image](https://github.com/dappforce/grillchat/assets/53143942/f9cb8889-d22a-4649-b10c-5563105117d0)
