### PR TITLE
Show error toast if user denied notification permission

### DIFF
--- a/src/components/auth/ProfileModal/contents/notifications/PushNotificationContent.tsx
+++ b/src/components/auth/ProfileModal/contents/notifications/PushNotificationContent.tsx
@@ -77,7 +77,7 @@ async function getMessageTokenWithCatch() {
         type='error'
         title='Failed to enable push notification'
         t={t}
-        description='If you are using Brave browser, please go to brave://settings/privacy and turn on "Use Google services for push messaging".'
+        description='If you are using Brave browser, please go to "brave://settings/privacy" and turn on "Use Google services for push messaging".'
       />
     ))
   }

--- a/src/components/auth/ProfileModal/contents/notifications/PushNotificationContent.tsx
+++ b/src/components/auth/ProfileModal/contents/notifications/PushNotificationContent.tsx
@@ -58,9 +58,20 @@ async function getMessageTokenWithCatch() {
   try {
     const fcmToken = await getMessageToken()
     console.log('FCM Token', fcmToken)
-    if (!fcmToken) return
+    if (!fcmToken) {
+      toast.custom((t) => (
+        <Toast
+          type='error'
+          title='Failed to enable push notification'
+          subtitle='Notification permission was not granted.'
+          t={t}
+          description='If you have blocked the notification permission, please go to your browser settings or go to "chrome://settings/content/notifications" and allow it.'
+        />
+      ))
+      return
+    }
     return fcmToken
-  } catch (err: any) {
+  } catch {
     toast.custom((t) => (
       <Toast
         type='error'


### PR DESCRIPTION
Currently, if its permission is denied, we don't do anything