### PR TITLE
Make Unread Count decrease based on visible messages

### DIFF
--- a/src/components/chats/ChatList/ChatItemContainer.tsx
+++ b/src/components/chats/ChatList/ChatItemContainer.tsx
@@ -3,7 +3,7 @@ import usePrevious from '@/hooks/usePrevious'
 import { useMessageData } from '@/stores/message'
 import { useMyAccount } from '@/stores/my-account'
 import { cx } from '@/utils/class-names'
-import { ComponentProps, forwardRef, useCallback, useEffect } from 'react'
+import { ComponentProps, forwardRef, useEffect } from 'react'
 import { useInView } from 'react-intersection-observer'
 import ChatItem, { ChatItemProps } from '../ChatItem'
 
@@ -77,25 +77,17 @@ function UnreadMessageChecker({ messageId }: { messageId: string }) {
   const setUnreadMessage = useMessageData((state) => state.setUnreadMessage)
   const prevCount = usePrevious(unreadMessage.count)
 
-  const handleInView = useCallback(
-    (isAfterScroll?: boolean) => {
-      setUnreadMessage((prev) => {
-        if (!prev.lastId || !prev.count) return prev
-
-        const prevLastId = Number(prev.lastId)
-        const currentMessageId = Number(messageId)
-        if (isAfterScroll || prevLastId < currentMessageId) {
-          return {
-            count: prev.count - 1,
-            lastId: Math.max(prevLastId, currentMessageId).toString(),
-          }
-        }
-
-        return prev
-      })
-    },
-    [messageId, setUnreadMessage]
-  )
+  const handleInView = (isAfterScroll?: boolean) => {
+    if (!unreadMessage.lastId || !unreadMessage.count) return
+    const prevLastId = Number(unreadMessage.lastId)
+    const currentMessageId = Number(messageId)
+    if (isAfterScroll || prevLastId < currentMessageId) {
+      setUnreadMessage((prev) => ({
+        count: prev.count - 1,
+        lastId: Math.max(prevLastId, currentMessageId).toString(),
+      }))
+    }
+  }
 
   const isPrevCountZero = prevCount === 0
   useEffect(() => {
@@ -107,7 +99,7 @@ function UnreadMessageChecker({ messageId }: { messageId: string }) {
       handleInView(true)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [handleInView, inView, isPrevCountZero, unreadMessage.count, messageId])
+  }, [inView, isPrevCountZero, unreadMessage.count, messageId])
 
   return (
     <div

--- a/src/components/chats/ChatList/ChatItemContainer.tsx
+++ b/src/components/chats/ChatList/ChatItemContainer.tsx
@@ -1,7 +1,10 @@
 import useIsMessageBlocked from '@/hooks/useIsMessageBlocked'
+import usePrevious from '@/hooks/usePrevious'
+import { useMessageData } from '@/stores/message'
 import { useMyAccount } from '@/stores/my-account'
 import { cx } from '@/utils/class-names'
-import { ComponentProps, forwardRef } from 'react'
+import { ComponentProps, forwardRef, useCallback, useEffect } from 'react'
+import { useInView } from 'react-intersection-observer'
 import ChatItem, { ChatItemProps } from '../ChatItem'
 
 export type ChatItemContainerProps = Omit<ChatItemProps, 'isMyMessage'> & {
@@ -52,6 +55,7 @@ function ChatItemContainer(
         containerProps?.className
       )}
     >
+      <UnreadMessageChecker messageId={message.id} />
       <ChatItem
         {...props}
         chatId={chatId}
@@ -59,6 +63,59 @@ function ChatItemContainer(
         hubId={hubId}
       />
     </div>
+  )
+}
+
+function UnreadMessageChecker({ messageId }: { messageId: string }) {
+  const { ref, inView } = useInView({
+    onChange: (inView) => {
+      if (inView) handleInView()
+    },
+  })
+
+  const unreadMessage = useMessageData((state) => state.unreadMessage)
+  const setUnreadMessage = useMessageData((state) => state.setUnreadMessage)
+  const prevCount = usePrevious(unreadMessage.count)
+
+  const handleInView = useCallback(
+    (isAfterScroll?: boolean) => {
+      setUnreadMessage((prev) => {
+        if (!prev.lastId || !prev.count) return prev
+
+        const prevLastId = Number(prev.lastId)
+        const currentMessageId = Number(messageId)
+        if (isAfterScroll || prevLastId < currentMessageId) {
+          return {
+            count: prev.count - 1,
+            lastId: Math.max(prevLastId, currentMessageId).toString(),
+          }
+        }
+
+        return prev
+      })
+    },
+    [messageId, setUnreadMessage]
+  )
+
+  const isPrevCountZero = prevCount === 0
+  useEffect(() => {
+    if (
+      inView &&
+      isPrevCountZero &&
+      Number(unreadMessage.lastId) < Number(messageId)
+    ) {
+      handleInView(true)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [handleInView, inView, isPrevCountZero, unreadMessage.count, messageId])
+
+  return (
+    <div
+      ref={ref}
+      onChange={(inView) => {
+        if (inView) handleInView()
+      }}
+    />
   )
 }
 

--- a/src/components/chats/ChatList/ChatListSupportingContent.tsx
+++ b/src/components/chats/ChatList/ChatListSupportingContent.tsx
@@ -40,7 +40,7 @@ export default function ChatListSupportingContent({
 }: ChatListSupportingContentProps) {
   const router = useRouter()
 
-  const [initialNewMessageCount, setInitialNewMessageCount] = useState(0)
+  const setUnreadMessage = useMessageData((state) => state.setUnreadMessage)
   const lastReadId = useFocusedLastMessageId(chatId)
   const [recipient, setRecipient] = useState('')
   const [messageModalMsgId, setMessageModalMsgId] = useState('')
@@ -77,7 +77,7 @@ export default function ChatListSupportingContent({
 
           sendMessageToParentWindow('unread', newMessageCount.toString())
 
-          setInitialNewMessageCount(newMessageCount)
+          setUnreadMessage({ count: newMessageCount, lastId: lastReadId })
         })
       }
       return
@@ -117,12 +117,10 @@ export default function ChatListSupportingContent({
       <Component>
         <div className='relative'>
           <NewMessageNotice
-            key={initialNewMessageCount}
             className={cx(
               'absolute bottom-2 right-3',
               newMessageNoticeClassName
             )}
-            initialNewMessageCount={initialNewMessageCount}
             messageIds={rawMessageIds ?? []}
             scrollContainerRef={scrollContainerRef}
           />

--- a/src/components/chats/ChatList/ChatListSupportingContent.tsx
+++ b/src/components/chats/ChatList/ChatListSupportingContent.tsx
@@ -66,13 +66,14 @@ export default function ChatListSupportingContent({
 
     if (!isMessageIdsFetched) return
 
-    isInitialized.current = true
     if (!messageId || !validateNumber(messageId)) {
       if (lastReadId) {
         scrollToMessage(lastReadId ?? '', {
           shouldHighlight: false,
           smooth: false,
         }).then(() => {
+          isInitialized.current = true
+
           const lastReadIdIndex = filteredMessageIdsRef.current.findIndex(
             (id) => id === lastReadId
           )
@@ -84,10 +85,13 @@ export default function ChatListSupportingContent({
           sendMessageToParentWindow('unread', newMessageCount.toString())
           setUnreadMessage({ count: newMessageCount, lastId: lastReadId })
         })
+      } else {
+        isInitialized.current = true
       }
       return
     }
 
+    isInitialized.current = true
     setMessageModalMsgId(messageId)
     setRecipient(recipient)
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/chats/ChatList/ChatListSupportingContent.tsx
+++ b/src/components/chats/ChatList/ChatListSupportingContent.tsx
@@ -3,6 +3,7 @@ import MessageModal from '@/components/modals/MessageModal'
 import useLastReadMessageIdFromStorage from '@/hooks/useLastReadMessageId'
 import usePrevious from '@/hooks/usePrevious'
 import useWrapInRef from '@/hooks/useWrapInRef'
+import { isOptimisticId } from '@/services/subsocial/utils'
 import { useMessageData } from '@/stores/message'
 import { cx } from '@/utils/class-names'
 import { getChatPageLink, getUrlQuery } from '@/utils/links'
@@ -95,13 +96,16 @@ export default function ChatListSupportingContent({
   useEffect(() => {
     if (!isInitialized.current) return
 
+    let lastId = ''
     if (unreadMessage.count === 0) {
-      const lastId = rawMessageIds?.[rawMessageIds.length - 1]
+      lastId = rawMessageIds?.[rawMessageIds.length - 1] ?? ''
       if (!lastId) return
-      setLastReadMessageId(lastId)
     } else {
-      setLastReadMessageId(unreadMessage.lastId)
+      lastId = unreadMessage.lastId
     }
+
+    if (isOptimisticId(lastId)) return
+    setLastReadMessageId(lastId)
   }, [setLastReadMessageId, rawMessageIds, unreadMessage])
 
   useEffect(() => {

--- a/src/components/chats/ChatList/NewMessageNotice.tsx
+++ b/src/components/chats/ChatList/NewMessageNotice.tsx
@@ -8,7 +8,6 @@ import useIsAtBottom from './hooks/useIsAtBottom'
 export type NewMessageNoticeProps = ButtonProps & {
   scrollContainerRef: RefObject<HTMLDivElement | null>
   messageIds: string[]
-  initialNewMessageCount?: number
   asContainer?: boolean
 }
 
@@ -18,14 +17,10 @@ export function NewMessageNotice({
   scrollContainerRef,
   messageIds,
   asContainer,
-  initialNewMessageCount,
   ...props
 }: NewMessageNoticeProps) {
   const isAtBottom = useIsAtBottom(scrollContainerRef, IS_AT_BOTTOM_OFFSET)
-  const { anyNewData, clearAnyNewData } = useAnyNewData(
-    messageIds.length,
-    initialNewMessageCount
-  )
+  const { anyNewData, clearAnyNewData } = useAnyNewData(messageIds)
 
   useEffect(() => {
     if (isAtBottom) clearAnyNewData()

--- a/src/components/chats/ChatList/hooks/useFocusedLastMessageId.ts
+++ b/src/components/chats/ChatList/hooks/useFocusedLastMessageId.ts
@@ -1,10 +1,10 @@
-import useLastReadMessageId from '@/hooks/useLastReadMessageId'
+import useLastReadMessageIdFromStorage from '@/hooks/useLastReadMessageId'
 import { useCommentIdsByPostId } from '@/services/subsocial/commentIds'
 import { isOptimisticId } from '@/services/subsocial/utils'
 import { useEffect, useRef, useState } from 'react'
 
 export default function useFocusedLastMessageId(chatId: string) {
-  const { getLastReadMessageId } = useLastReadMessageId(chatId)
+  const { getLastReadMessageId } = useLastReadMessageIdFromStorage(chatId)
   const [lastReadId, setLastReadId] = useState(() => getLastReadMessageId())
   const shouldUpdateLastReadId = useRef(false)
 

--- a/src/components/chats/ChatPreview/ChatUnreadCount.tsx
+++ b/src/components/chats/ChatPreview/ChatUnreadCount.tsx
@@ -1,4 +1,4 @@
-import useLastReadMessageId from '@/hooks/useLastReadMessageId'
+import useLastReadMessageIdFromStorage from '@/hooks/useLastReadMessageId'
 import { useCommentIdsByPostId } from '@/services/subsocial/commentIds'
 import { cx } from '@/utils/class-names'
 import { ComponentProps, useMemo } from 'react'
@@ -11,7 +11,7 @@ export default function ChatUnreadCount({
   chatId,
   ...props
 }: ChatUnreadCountProps) {
-  const { getLastReadMessageId } = useLastReadMessageId(chatId)
+  const { getLastReadMessageId } = useLastReadMessageIdFromStorage(chatId)
   const { data: messageIds } = useCommentIdsByPostId(chatId)
 
   const lastReadId = getLastReadMessageId()
@@ -28,7 +28,7 @@ export default function ChatUnreadCount({
   return (
     <div
       className={cx(
-        'rounded-full bg-background-primary py-0.5 px-2 text-sm text-text-on-primary',
+        'rounded-full bg-background-primary px-2 py-0.5 text-sm text-text-on-primary',
         props.className
       )}
     >

--- a/src/hooks/useLastReadMessageId.ts
+++ b/src/hooks/useLastReadMessageId.ts
@@ -4,7 +4,7 @@ import { useCallback } from 'react'
 const getStorageKey = (chatId: string) => `last-read-${chatId}`
 const storage = new LocalStorage(getStorageKey)
 
-export default function useLastReadMessageId(chatId: string) {
+export default function useLastReadMessageIdFromStorage(chatId: string) {
   const getLastReadMessageId = useCallback(() => storage.get(chatId), [chatId])
   const setLastReadMessageId = useCallback(
     (id: string) => storage.set(id, chatId),

--- a/src/modules/chat/ChatPage/ChatPage.tsx
+++ b/src/modules/chat/ChatPage/ChatPage.tsx
@@ -21,6 +21,7 @@ import { getModeratorQuery } from '@/services/api/moderation/query'
 import { getPostQuery } from '@/services/api/query'
 import { useCommentIdsByPostId } from '@/services/subsocial/commentIds'
 import { useExtensionData } from '@/stores/extension'
+import { useMessageData } from '@/stores/message'
 import { useMyAccount } from '@/stores/my-account'
 import { cx } from '@/utils/class-names'
 import { getIpfsContentUrl } from '@/utils/ipfs'
@@ -59,6 +60,11 @@ export default function ChatPage({
   chatId = '',
   stubMetadata,
 }: ChatPageProps) {
+  const resetMessageData = useMessageData((state) => state.reset)
+  useEffect(() => {
+    return () => resetMessageData()
+  }, [resetMessageData])
+
   const router = useRouter()
   const [isOpenCreateSuccessModal, setIsOpenCreateSuccessModal] =
     useState(false)

--- a/src/stores/message.ts
+++ b/src/stores/message.ts
@@ -7,6 +7,10 @@ const messageCountStorage = new LocalStorage(
   (origin: string) => `${MESSAGE_COUNT_STORAGE_KEY}:${origin}`
 )
 
+type UnreadMessage = {
+  lastId: string
+  count: number
+}
 type State = {
   messageCount: number
 
@@ -14,6 +18,8 @@ type State = {
   replyTo: string | undefined
 
   showEmptyPrimaryChatInput: boolean
+
+  unreadMessage: UnreadMessage
 }
 
 type Actions = {
@@ -22,6 +28,9 @@ type Actions = {
   setReplyTo: (replyTo: string) => void
   clearReplyTo: () => void
   setShowEmptyPrimaryChatInput: (show: boolean) => void
+  setUnreadMessage: (
+    unreadData: UnreadMessage | ((prev: UnreadMessage) => UnreadMessage)
+  ) => void
 }
 
 const INITIAL_STATE: State = {
@@ -29,6 +38,10 @@ const INITIAL_STATE: State = {
   messageBody: '',
   replyTo: '',
   showEmptyPrimaryChatInput: false,
+  unreadMessage: {
+    count: 0,
+    lastId: '',
+  },
 }
 
 export const useMessageData = create<State & Actions>()((set, get) => ({
@@ -53,6 +66,13 @@ export const useMessageData = create<State & Actions>()((set, get) => ({
   },
   setShowEmptyPrimaryChatInput: (show: boolean) => {
     set({ showEmptyPrimaryChatInput: show })
+  },
+  setUnreadMessage: (unreadMessage) => {
+    if (typeof unreadMessage === 'function') {
+      set((state) => ({ unreadMessage: unreadMessage(state.unreadMessage) }))
+      return
+    }
+    set({ unreadMessage })
   },
   init: () => {
     const { parentOrigin } = useParentData.getState()

--- a/src/stores/message.ts
+++ b/src/stores/message.ts
@@ -23,6 +23,7 @@ type State = {
 }
 
 type Actions = {
+  reset: () => void
   incrementMessageCount: () => void
   setMessageBody: (message: string) => void
   setReplyTo: (replyTo: string) => void
@@ -73,6 +74,9 @@ export const useMessageData = create<State & Actions>()((set, get) => ({
       return
     }
     set({ unreadMessage })
+  },
+  reset: () => {
+    set(INITIAL_STATE)
   },
   init: () => {
     const { parentOrigin } = useParentData.getState()


### PR DESCRIPTION
# Changes
- Improve unread count decreasing
- Update last read message ids in storage based on last visible message instead of instantly to new id after user visits page

# Waiting finish testing