### PR TITLE
Add miro medium to image hostname

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -58,12 +58,17 @@ const nextConfig = {
       },
       {
         protocol: 'https',
-        hostname: '**',
+        hostname: 'miro.medium.com',
+        port: '',
       },
       {
         protocol: 'https',
         hostname: 'metadata.ens.domains',
         port: '',
+      },
+      {
+        protocol: 'https',
+        hostname: '**',
       },
     ],
   },


### PR DESCRIPTION
Fix: Issue where medium link preview image won't show up because it has 403 from the next image