### PR TITLE
Add retries to sending message

### DIFF
--- a/src/components/chats/ChatForm.tsx
+++ b/src/components/chats/ChatForm.tsx
@@ -100,16 +100,16 @@ export default function ChatForm({
   )
   const [isRequestingEnergy, setIsRequestingEnergy] = useState(false)
 
-  const { mutateAsync: requestTokenAndSendMessage } =
-    useRequestTokenAndSendMessage({
-      onError: (error, variables) => {
-        showErrorSendingMessageToast(
-          error,
-          'Failed to register or send message',
-          variables
-        )
-      },
-    })
+  const { mutate: requestTokenAndSendMessage } = useRequestTokenAndSendMessage({
+    onSuccess: () => unsentMessageStorage.remove(chatId),
+    onError: (error, variables) => {
+      showErrorSendingMessageToast(
+        error,
+        'Failed to register or send message',
+        variables
+      )
+    },
+  })
 
   let messageBody = useMessageData((state) => state.messageBody)
   const showEmptyPrimaryChatInput = useMessageData(
@@ -120,6 +120,7 @@ export default function ChatForm({
   }
 
   const { mutate: sendMessage } = useSendMessage({
+    onSuccess: () => unsentMessageStorage.remove(chatId),
     onError: (error, variables) => {
       showErrorSendingMessageToast(error, 'Failed to send message', variables)
     },
@@ -188,6 +189,8 @@ export default function ChatForm({
         setIsOpenNameModal(true)
       }, 1000)
     }
+
+    unsentMessageStorage.set(JSON.stringify(messageParams), chatId)
     hasSentMessageStorage.set('true')
 
     if (shouldSendMessage) {

--- a/src/components/chats/ChatList/ChatList.tsx
+++ b/src/components/chats/ChatList/ChatList.tsx
@@ -25,6 +25,7 @@ import {
 import InfiniteScroll from 'react-infinite-scroll-component'
 import CenterChatNotice from './CenterChatNotice'
 import MemoizedChatItemWithMenu from './ChatItemWithMenu'
+import ChatListEventManager from './ChatListEventManager'
 import ChatListSupportingContent from './ChatListSupportingContent'
 import ChatLoading from './ChatLoading'
 import ChatTopNotice from './ChatTopNotice'
@@ -169,6 +170,7 @@ function ChatListContent({
 
   return (
     <ChatListContext.Provider value={scrollContainerRef}>
+      <ChatListEventManager />
       <div
         {...props}
         className={cx(

--- a/src/components/chats/ChatList/ChatListEventManager.tsx
+++ b/src/components/chats/ChatList/ChatListEventManager.tsx
@@ -1,0 +1,49 @@
+import useIsInIframe from '@/hooks/useIsInIframe'
+import { useSendEvent } from '@/stores/analytics'
+import { debounce } from '@/utils/general'
+import { useEffect } from 'react'
+import { useChatListContext } from './ChatList'
+
+export default function ChatListEventManager() {
+  const containerRef = useChatListContext()
+  const sendEvent = useSendEvent()
+  const isInIframe = useIsInIframe()
+
+  useEffect(() => {
+    const container = containerRef?.current
+    if (!container) return
+
+    const listener = debounce(() => {
+      sendEvent('read_chat', { eventSource: 'click' })
+    }, 500)
+    container.addEventListener('click', listener)
+
+    return () => container.removeEventListener('click', listener)
+  }, [containerRef, sendEvent])
+
+  useEffect(() => {
+    if (!isInIframe) return
+    const container = containerRef?.current
+    if (!container) return
+
+    const listener = () => {
+      sendEvent('read_chat', { eventSource: 'mouse_enter' })
+    }
+    container.addEventListener('mouseenter', listener, { once: true })
+
+    return () => container.removeEventListener('scroll', listener)
+  }, [isInIframe, containerRef, sendEvent])
+
+  useEffect(() => {
+    const container = containerRef?.current
+    if (!container) return
+
+    const debouncedListener = debounce(() => {
+      sendEvent('read_chat', { eventSource: 'scroll' })
+    }, 500)
+    container.addEventListener('scroll', debouncedListener, { passive: true })
+    return () => container.removeEventListener('scroll', debouncedListener)
+  }, [containerRef, sendEvent])
+
+  return null
+}

--- a/src/services/api/mutation.ts
+++ b/src/services/api/mutation.ts
@@ -33,7 +33,7 @@ export async function saveFile(content: SaveFileRequest) {
   if (!data.success) throw new Error(data.errors)
   return data
 }
-export const useSaveFile = mutationWrapper(saveFile)
+export const useSaveFile = mutationWrapper(saveFile, { retry: 2 })
 
 export async function createUserId(address: string) {
   const res = await axios.post('/api/create-user-id', { address })

--- a/src/services/subsocial/commentIds/mutation.ts
+++ b/src/services/subsocial/commentIds/mutation.ts
@@ -52,6 +52,7 @@ export function useSendMessage(config?: MutationConfig<SendMessageParams>) {
     },
     config,
     {
+      retry: 2,
       txCallbacks: {
         // Removal of optimistic message generated is done by the subscription of messageIds
         // this is done to prevent a bit of flickering because the optimistic message is done first, before the message data finished fetching

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -1,3 +1,11 @@
 export function isEmptyObject(obj: Record<string, unknown>) {
   return Object.keys(obj).length === 0
 }
+
+export function debounce(fn: Function, ms = 300) {
+  let timeoutId: ReturnType<typeof setTimeout>
+  return function (this: any, ...args: any[]) {
+    clearTimeout(timeoutId)
+    timeoutId = setTimeout(() => fn.apply(this, args), ms)
+  }
+}

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,6 +1,8 @@
 import Compressor from 'compressorjs'
 
-export function resizeImage(file: File): Promise<File> {
+export function resizeImage(file: File): Promise<File> | File {
+  if (file.size < 1024 * 1024) return file
+
   return new Promise((resolve) => {
     new Compressor(file, {
       maxWidth: 1024,


### PR DESCRIPTION
# Other changes
- If file is < 1mb, it doesn't get compressed in frontend side (svg compression in backend side works good, while in frontend part its not)
- Save unsent message even before error toast appears
- Add read_chat events with 3 different interaction sources