### PR TITLE
Fix Issue where menu color not using correct theme

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -94,7 +94,7 @@ function AppContent({ Component, pageProps }: AppProps<AppCommonProps>) {
         />
         <HeadConfig {...head} />
         <GoogleAnalytics trackPageViews gaMeasurementId={getGaId()} />
-        <div className={cx('font-s33ns')}>
+        <div className={cx('font-sans')}>
           <ErrorBoundary>
             <EvmProvider>
               <Component {...props} />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -63,6 +63,7 @@
 html,
 body {
   @apply font-sans;
+  @apply text-text;
   @apply text-base;
   @apply bg-background;
 }


### PR DESCRIPTION
# Issue
In some cases, the color of the message menu color is black in dark theme
The cause is because it inherits color from body, and its using black color there