### PR TITLE
Remove Retry in Sending Message Mutation

### DIFF
--- a/src/pages/api/version.ts
+++ b/src/pages/api/version.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-const VERSION = '13'
+const VERSION = '14'
 
 export default function handler(_: NextApiRequest, res: NextApiResponse) {
   res.status(200).json(VERSION)

--- a/src/pages/api/version.ts
+++ b/src/pages/api/version.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-const VERSION = '12'
+const VERSION = '13'
 
 export default function handler(_: NextApiRequest, res: NextApiResponse) {
   res.status(200).json(VERSION)

--- a/src/services/subsocial/commentIds/mutation.ts
+++ b/src/services/subsocial/commentIds/mutation.ts
@@ -118,7 +118,6 @@ export function useSendMessage(config?: MutationConfig<SendMessageParams>) {
     {
       // to make the error invisible to user if the tx was created (in this case, post was sent to dh)
       supressSendingTxError: !!getDatahubConfig(),
-      retry: 2,
       txCallbacks: {
         onStart: ({ address, context, data }) => {
           preventWindowUnload()


### PR DESCRIPTION
This is so rate limit error (toast) appear when user is rate limited, rather than retrying and have the message order messed up