### PR TITLE
Set prefetched message data to dehydrate

### DIFF
--- a/src/components/auth/common/evm/CommonEvmModalContent.tsx
+++ b/src/components/auth/common/evm/CommonEvmModalContent.tsx
@@ -58,7 +58,7 @@ export const CommonEvmAddressLinked = () => {
         onClick={() => openNewWindow(twitterUrl)}
         className='w-full'
       >
-        Tweet about it!
+        Post about it on X!
       </Button>
     </div>
   )

--- a/src/components/community/ChatCreateSuccessModal.tsx
+++ b/src/components/community/ChatCreateSuccessModal.tsx
@@ -63,7 +63,7 @@ export default function ChatCreateSuccessModal({
               )
             }
           >
-            Tweet about it!
+            Post about it on X!
           </Button>
         </div>
       </div>

--- a/src/pages/[hubId]/[slug]/index.tsx
+++ b/src/pages/[hubId]/[slug]/index.tsx
@@ -77,6 +77,9 @@ async function getMessageIdsFromDatahub(client: QueryClient, chatId: string) {
     )
   getPaginatedPostsByPostIdFromDatahubQuery.invalidateFirstQuery(client, chatId)
   const messages = await getPostsServer(res.data)
+  messages.forEach((message) => {
+    getPostQuery.setQueryData(client, message.id, message)
+  })
 
   return { messageIds: res.data, messages }
 }

--- a/src/pages/api/version.ts
+++ b/src/pages/api/version.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-const VERSION = '16'
+const VERSION = '17'
 
 export default function handler(_: NextApiRequest, res: NextApiResponse) {
   res.status(200).json(VERSION)


### PR DESCRIPTION
# Issue
Currently, the first page messages data that were prefetched in server are not sent to dehydrate, making the user sees only last message for 1 sec before other messages loaded