### PR TITLE
Improve caching of Identities

### DIFF
--- a/src/pages/api/identities.ts
+++ b/src/pages/api/identities.ts
@@ -35,7 +35,6 @@ export default handlerWrapper({
       : [data.addresses]
 
     const identities = await getIdentities(addresses)
-    console.log('done finished')
     return res
       .status(200)
       .send({ success: true, message: 'OK', data: identities })
@@ -58,7 +57,6 @@ async function getIdentities(addresses: string[]): Promise<Identities[]> {
   const subsocialIdentities =
     subsocialPromise.status === 'fulfilled' ? subsocialPromise.value : {}
 
-  console.log('finished')
   return addresses.map((address) => {
     const polkadot = identities[address]?.polkadot
     const kusama = identities[address]?.kusama
@@ -89,7 +87,6 @@ async function getPolkadotAndKusamaIdentities(addresses: string[]) {
     const cached = await redisCallWrapper((redis) =>
       redis?.get(getIdentitiesRedisKey(address, 'polkadot'))
     )
-    console.log('POLKADOT: get cached data', cached, address)
     try {
       if (cached) {
         const parsed = JSON.parse(cached) as {
@@ -134,11 +131,6 @@ async function getPolkadotAndKusamaIdentities(addresses: string[]) {
     if (identity?.kusama?.info?.display) {
       savedIdentity.kusama = identity.kusama.info.display
     }
-    console.log(
-      'POLKADOT: setting cached data',
-      JSON.stringify(savedIdentity),
-      address
-    )
     redisCallWrapper((redis) =>
       redis?.set(
         getIdentitiesRedisKey(address, 'polkadot'),
@@ -150,7 +142,6 @@ async function getPolkadotAndKusamaIdentities(addresses: string[]) {
     names[address] = savedIdentity
   })
 
-  console.log('POLKADOT FINISHED')
   return names
 }
 
@@ -162,7 +153,6 @@ async function getKiltIdentities(addresses: string[]) {
     const cached = await redisCallWrapper((redis) =>
       redis?.get(getIdentitiesRedisKey(address, 'kilt'))
     )
-    console.log('KILT: get cached data', cached, address)
     try {
       if (cached) {
         const parsed = JSON.parse(cached) as { name?: string }
@@ -199,7 +189,6 @@ async function getKiltIdentities(addresses: string[]) {
     if (name) w3names[address] = name
   })
 
-  console.log('KILT FINISHED')
   return w3names
 }
 
@@ -232,7 +221,6 @@ async function getSubsocialUsernames(addresses: string[]) {
     const cached = await redisCallWrapper((redis) =>
       redis?.get(getIdentitiesRedisKey(address, 'subsocial'))
     )
-    console.log('SUBSOCIAL: get cached data', cached, address)
     try {
       if (cached) {
         const parsed = JSON.parse(cached) as string[]
@@ -266,7 +254,6 @@ async function getSubsocialUsernames(addresses: string[]) {
     const account = accountsMap[address]
     const { id, usernames = [] } = account || {}
 
-    console.log('SUBSOCIAL: setting cached data', JSON.stringify(usernames), id)
     redisCallWrapper((redis) =>
       redis?.set(
         getIdentitiesRedisKey(id, 'subsocial'),
@@ -278,6 +265,5 @@ async function getSubsocialUsernames(addresses: string[]) {
     if (usernames.length > 0) usernamesMap[id] = usernames
   })
 
-  console.log('SUBSOCIAL FINISHED')
   return usernamesMap
 }

--- a/src/pages/api/identities.ts
+++ b/src/pages/api/identities.ts
@@ -87,6 +87,7 @@ async function getPolkadotAndKusamaIdentities(addresses: string[]) {
     const cached = await redisCallWrapper((redis) =>
       redis?.get(getIdentitiesRedisKey(address, 'polkadot'))
     )
+    console.log('POLKADOT: get cached data', cached, address)
     try {
       if (cached) {
         const parsed = JSON.parse(cached) as {
@@ -131,6 +132,11 @@ async function getPolkadotAndKusamaIdentities(addresses: string[]) {
     if (identity?.kusama?.info?.display) {
       savedIdentity.kusama = identity.kusama.info.display
     }
+    console.log(
+      'POLKADOT: setting cached data',
+      JSON.stringify(savedIdentity),
+      address
+    )
     redisCallWrapper((redis) =>
       redis?.set(
         getIdentitiesRedisKey(address, 'polkadot'),
@@ -142,6 +148,7 @@ async function getPolkadotAndKusamaIdentities(addresses: string[]) {
     names[address] = savedIdentity
   })
 
+  console.log('POLKADOT FINISHED')
   return names
 }
 
@@ -153,6 +160,7 @@ async function getKiltIdentities(addresses: string[]) {
     const cached = await redisCallWrapper((redis) =>
       redis?.get(getIdentitiesRedisKey(address, 'kilt'))
     )
+    console.log('KILT: get cached data', cached, address)
     try {
       if (cached) {
         const parsed = JSON.parse(cached) as { name?: string }
@@ -175,6 +183,7 @@ async function getKiltIdentities(addresses: string[]) {
 
     const name = namePromise.value
     const address = needToFetchAddresses[i]
+    console.log('KILT: setting cached data', JSON.stringify({ name }), address)
     redisCallWrapper((redis) =>
       redis?.set(
         getIdentitiesRedisKey(address, 'kilt'),
@@ -186,6 +195,7 @@ async function getKiltIdentities(addresses: string[]) {
     if (name) w3names[address] = name
   })
 
+  console.log('KILT FINISHED')
   return w3names
 }
 
@@ -218,6 +228,7 @@ async function getSubsocialUsernames(addresses: string[]) {
     const cached = await redisCallWrapper((redis) =>
       redis?.get(getIdentitiesRedisKey(address, 'subsocial'))
     )
+    console.log('SUBSOCIAL: get cached data', cached, address)
     try {
       if (cached) {
         const parsed = JSON.parse(cached) as string[]
@@ -241,8 +252,9 @@ async function getSubsocialUsernames(addresses: string[]) {
     variables: { addresses: needToFetchAddresses },
   })) as { accounts: { id: string; usernames: string[] }[] }
 
-  res.accounts.forEach((accountData, i) => {
+  res.accounts.forEach((accountData) => {
     const { id, usernames } = accountData
+    console.log('SUBSOCIAL: setting cached data', JSON.stringify(usernames), id)
     redisCallWrapper((redis) =>
       redis?.set(
         getIdentitiesRedisKey(id, 'subsocial'),
@@ -254,5 +266,6 @@ async function getSubsocialUsernames(addresses: string[]) {
     if (usernames.length > 0) usernamesMap[id] = usernames
   })
 
+  console.log('SUBSOCIAL FINISHED')
   return usernamesMap
 }


### PR DESCRIPTION
# Issue
Currently for subsocial and kilt, only identities that exists are cached, addresses that don't have identities were'nt cached, making the request takes long because they still fetch identities of those addresses