### PR TITLE
Improve Name Loading Speed

### DIFF
--- a/src/components/Name.tsx
+++ b/src/components/Name.tsx
@@ -32,20 +32,30 @@ export function useName(
   address: string,
   forceProfileSource?: ForceProfileSource
 ) {
-  const { data: accountData, isLoading: isLoadingEvm } =
-    getAccountDataQuery.useQuery(address)
   const { data: profile, isLoading: isLoadingProfile } =
     getProfileQuery.useQuery(address)
+  const { data: accountData, isLoading: isLoadingEvm } =
+    getAccountDataQuery.useQuery(address)
   const textColor = useRandomColor(address, { isAddress: true })
-  const { data: identities, isLoading: isLoadingIdentities } =
+
+  const userProfileSource = profile?.profileSpace?.content?.profileSource
+
+  const { source } = decodeProfileSource(userProfileSource)
+  const identitiesNeededInSources: ProfileSource[] = [
+    'kilt-w3n',
+    'kusama-identity',
+    'polkadot-identity',
+    'subsocial-username',
+  ]
+  const { data: identities, isFetching: isFetchingIdentities } =
     getIdentityQuery.useQuery(address ?? '', {
-      enabled: !!address,
+      enabled: identitiesNeededInSources.includes(
+        forceProfileSource?.profileSource || source
+      ),
     })
 
   const { ensNames, evmAddress } = accountData || {}
   let name = generateRandomName(address)
-
-  const userProfileSource = profile?.profileSpace?.content?.profileSource
 
   function getNameFromSource(profileSource?: ProfileSource, content?: string) {
     switch (profileSource) {
@@ -87,7 +97,7 @@ export function useName(
     accountData,
     profile,
     evmAddress,
-    isLoading: isLoadingEvm || isLoadingProfile || isLoadingIdentities,
+    isLoading: isLoadingEvm || isLoadingProfile || isFetchingIdentities,
     textColor,
     ensNames,
   }

--- a/src/components/Name.tsx
+++ b/src/components/Name.tsx
@@ -47,12 +47,14 @@ export function useName(
     'polkadot-identity',
     'subsocial-username',
   ]
+  const isIdentitiesNeeded = identitiesNeededInSources.includes(
+    forceProfileSource?.profileSource || source
+  )
   const { data: identities, isFetching: isFetchingIdentities } =
     getIdentityQuery.useQuery(address ?? '', {
-      enabled: identitiesNeededInSources.includes(
-        forceProfileSource?.profileSource || source
-      ),
+      enabled: isIdentitiesNeeded,
     })
+  const isLoadingIdentities = isFetchingIdentities && isIdentitiesNeeded
 
   const { ensNames, evmAddress } = accountData || {}
   let name = generateRandomName(address)
@@ -97,7 +99,7 @@ export function useName(
     accountData,
     profile,
     evmAddress,
-    isLoading: isLoadingEvm || isLoadingProfile || isFetchingIdentities,
+    isLoading: isLoadingEvm || isLoadingProfile || isLoadingIdentities,
     textColor,
     ensNames,
   }

--- a/src/components/auth/ProfileModal/contents/ProfileSettingsContent/EvmProfileTabContent.tsx
+++ b/src/components/auth/ProfileModal/contents/ProfileSettingsContent/EvmProfileTabContent.tsx
@@ -16,7 +16,8 @@ export default function EvmProfileTabContent({
   setSelectedEns,
   setCurrentState,
 }: ContentProps & { setSelectedEns: (ens: string) => void }) {
-  const { data: accountData } = getAccountDataQuery.useQuery(address)
+  const { data: accountData, isLoading: isLoadingAccountData } =
+    getAccountDataQuery.useQuery(address)
   const { data: profile } = getProfileQuery.useQuery(address)
   const evmAddress = accountData?.evmAddress
   const ensNames = accountData?.ensNames
@@ -101,13 +102,15 @@ export default function EvmProfileTabContent({
               items={ensOptions}
               selected={selected ?? null}
               setSelected={setSelected}
-              placeholder='Select your ENS'
+              placeholder={
+                isLoadingAccountData ? 'Loading...' : 'Select your ENS'
+              }
             />
             <Button
               type='submit'
               isLoading={isLoading}
               size='lg'
-              disabled={isCurrentProfile}
+              disabled={isCurrentProfile || isLoadingAccountData}
             >
               {isCurrentProfile ? 'Your current profile' : 'Save changes'}
             </Button>

--- a/src/components/auth/ProfileModal/contents/ProfileSettingsContent/PolkadotProfileTabContent.tsx
+++ b/src/components/auth/ProfileModal/contents/ProfileSettingsContent/PolkadotProfileTabContent.tsx
@@ -35,12 +35,10 @@ export default function PolkadotProfileTabContent({
 
   const parentProxyAddress = useMyAccount((state) => state.parentProxyAddress)
   const hasConnectedPolkadot = !!parentProxyAddress
-  const { data: identities } = getIdentityQuery.useQuery(
-    parentProxyAddress ?? '',
-    {
+  const { data: identities, isLoading: isLoadingIdentity } =
+    getIdentityQuery.useQuery(parentProxyAddress ?? '', {
       enabled: !!parentProxyAddress,
-    }
-  )
+    })
 
   const identitiesOptions = useMemo(() => {
     const options: ListItem[] = []
@@ -223,11 +221,13 @@ export default function PolkadotProfileTabContent({
               items={identitiesOptions}
               selected={selected ?? null}
               setSelected={setSelected}
-              placeholder='Select identity provider'
+              placeholder={
+                isLoadingIdentity ? 'Loading...' : 'Select identity provider'
+              }
             />
             <Button
               type='submit'
-              isLoading={isLoading}
+              isLoading={isLoading || isLoadingIdentity}
               size='lg'
               disabled={!selected?.id || isCurrentProfile}
             >

--- a/src/components/auth/ProfileModal/contents/ProfileSettingsContent/PolkadotProfileTabContent.tsx
+++ b/src/components/auth/ProfileModal/contents/ProfileSettingsContent/PolkadotProfileTabContent.tsx
@@ -35,7 +35,7 @@ export default function PolkadotProfileTabContent({
 
   const parentProxyAddress = useMyAccount((state) => state.parentProxyAddress)
   const hasConnectedPolkadot = !!parentProxyAddress
-  const { data: identities, isLoading: isLoadingIdentity } =
+  const { data: identities, isFetching: isFetchingIdentities } =
     getIdentityQuery.useQuery(parentProxyAddress ?? '', {
       enabled: !!parentProxyAddress,
     })
@@ -139,7 +139,8 @@ export default function PolkadotProfileTabContent({
     !identities?.polkadot &&
     !identities?.kilt &&
     !identities?.kusama &&
-    !identities?.subsocial?.length
+    !identities?.subsocial?.length &&
+    !isFetchingIdentities
   ) {
     return (
       <p className='text-text-muted'>
@@ -222,12 +223,12 @@ export default function PolkadotProfileTabContent({
               selected={selected ?? null}
               setSelected={setSelected}
               placeholder={
-                isLoadingIdentity ? 'Loading...' : 'Select identity provider'
+                isFetchingIdentities ? 'Loading...' : 'Select identity provider'
               }
             />
             <Button
               type='submit'
-              isLoading={isLoading || isLoadingIdentity}
+              isLoading={isLoading || isFetchingIdentities}
               size='lg'
               disabled={!selected?.id || isCurrentProfile}
             >

--- a/src/components/auth/ProfileModal/contents/ProfileSettingsContent/ProfileSettingsContent.tsx
+++ b/src/components/auth/ProfileModal/contents/ProfileSettingsContent/ProfileSettingsContent.tsx
@@ -91,7 +91,7 @@ export default function ProfileSettingsContent(props: ContentProps) {
       break
     case 1:
       forceProfileSource = {
-        profileSource: selectedPolkadotIdentity?.source,
+        profileSource: selectedPolkadotIdentity?.source ?? 'polkadot-identity',
         content: selectedPolkadotIdentity?.content,
       }
       break

--- a/src/pages/[hubId]/[slug]/index.tsx
+++ b/src/pages/[hubId]/[slug]/index.tsx
@@ -170,13 +170,11 @@ export const getStaticProps = getCommonStaticProps<
       getPostQuery.setQueryData(queryClient, chatId, chatData)
 
       accountsAddresses.forEach((accountAddresses) => {
-        if (accountAddresses.evmAddress) {
-          getAccountDataQuery.setQueryData(
-            queryClient,
-            accountAddresses.grillAddress,
-            accountAddresses
-          )
-        }
+        getAccountDataQuery.setQueryData(
+          queryClient,
+          accountAddresses.grillAddress,
+          accountAddresses
+        )
       })
       prices.forEach((price) => {
         const { id, current_price } = price || {}

--- a/src/pages/[hubId]/[slug]/index.tsx
+++ b/src/pages/[hubId]/[slug]/index.tsx
@@ -4,9 +4,10 @@ import ChatPage, { ChatPageProps } from '@/modules/chat/ChatPage'
 import { getAccountsDataFromCache } from '@/pages/api/accounts-data'
 import { getPostsServer } from '@/pages/api/posts'
 import { getPricesFromCache } from '@/pages/api/prices'
+import { getProfilesServer } from '@/pages/api/profiles'
 import { AppCommonProps } from '@/pages/_app'
 import { prefetchBlockedEntities } from '@/server/moderation/prefetch'
-import { getPostQuery } from '@/services/api/query'
+import { getPostQuery, getProfileQuery } from '@/services/api/query'
 import { getCommentIdsByPostIdFromChainQuery } from '@/services/subsocial/commentIds'
 import {
   getPaginatedPostsByPostIdFromDatahubQuery,
@@ -18,6 +19,7 @@ import {
   getPriceQuery,
 } from '@/services/subsocial/prices/query'
 import { getDatahubConfig } from '@/utils/env/client'
+import { removeUndefinedValues } from '@/utils/general'
 import { getIpfsContentUrl } from '@/utils/ipfs'
 import { getCommonStaticProps } from '@/utils/page'
 import { getIdFromSlug } from '@/utils/slug'
@@ -50,15 +52,32 @@ async function getChatsData(client: QueryClient, chatId: string) {
 
   const prices = await getPricesFromCache(Object.values(coingeckoTokenIds))
 
-  const accountsAddresses = await getAccountsDataFromCache(
-    chatPageOwnerIds,
-    'GET'
-  )
+  const [accountsDataPromise, profilesPromise] = await Promise.allSettled([
+    getAccountsDataFromCache(chatPageOwnerIds, 'GET'),
+    getProfilesServer(chatPageOwnerIds),
+  ] as const)
+  if (accountsDataPromise.status === 'fulfilled') {
+    accountsDataPromise.value.forEach((accountAddresses) => {
+      getAccountDataQuery.setQueryData(
+        client,
+        accountAddresses.grillAddress,
+        accountAddresses
+      )
+    })
+  }
+  if (profilesPromise.status === 'fulfilled') {
+    profilesPromise.value.forEach((profile) => {
+      getProfileQuery.setQueryData(
+        client,
+        profile.address,
+        removeUndefinedValues(profile)
+      )
+    })
+  }
 
   return {
     messages,
     messageIds,
-    accountsAddresses,
     prices,
   }
 }
@@ -137,7 +156,7 @@ export const getStaticProps = getCommonStaticProps<
         hubIds.push(originalHubId)
       }
 
-      const [{ accountsAddresses, prices }, blockedData] = await Promise.all([
+      const [{ prices }, blockedData] = await Promise.all([
         getChatsData(queryClient, chatId),
         prefetchBlockedEntities(queryClient, hubIds, [chatId]),
         prefetchPostMetadata(queryClient, chatId),
@@ -169,13 +188,6 @@ export const getStaticProps = getCommonStaticProps<
 
       getPostQuery.setQueryData(queryClient, chatId, chatData)
 
-      accountsAddresses.forEach((accountAddresses) => {
-        getAccountDataQuery.setQueryData(
-          queryClient,
-          accountAddresses.grillAddress,
-          accountAddresses
-        )
-      })
       prices.forEach((price) => {
         const { id, current_price } = price || {}
 

--- a/src/server/chats.ts
+++ b/src/server/chats.ts
@@ -6,6 +6,7 @@ import { getPostMetadataQuery } from '@/services/subsocial/datahub/posts/query'
 import { getPostIdsBySpaceIdQuery } from '@/services/subsocial/posts'
 import { getSpaceQuery } from '@/services/subsocial/spaces'
 import { getDatahubConfig } from '@/utils/env/client'
+import { removeUndefinedValues } from '@/utils/general'
 import { PostData } from '@subsocial/api/types'
 import { QueryClient } from '@tanstack/react-query'
 import { prefetchBlockedEntities } from './moderation/prefetch'
@@ -38,11 +39,7 @@ export async function prefetchChatPreviewsData(
     allChatIds
   )
   ;[...lastMessages, ...chats].forEach((post) => {
-    getPostQuery.setQueryData(
-      queryClient,
-      post.id,
-      JSON.parse(JSON.stringify(post)) as PostData
-    )
+    getPostQuery.setQueryData(queryClient, post.id, removeUndefinedValues(post))
   })
 }
 

--- a/src/services/subsocial/datahub/generated-query.ts
+++ b/src/services/subsocial/datahub/generated-query.ts
@@ -453,7 +453,11 @@ export type DatahubPostFragmentFragment = {
     toEvm?: { __typename?: 'EvmAccount'; id: string } | null
     pinnedResources?: Array<{
       __typename?: 'ExtensionPinnedResource'
-      post?: { __typename?: 'Post'; id: string } | null
+      post?: {
+        __typename?: 'Post'
+        id: string
+        persistentId?: string | null
+      } | null
     }> | null
   }>
 }
@@ -524,7 +528,11 @@ export type GetPostsQuery = {
         toEvm?: { __typename?: 'EvmAccount'; id: string } | null
         pinnedResources?: Array<{
           __typename?: 'ExtensionPinnedResource'
-          post?: { __typename?: 'Post'; id: string } | null
+          post?: {
+            __typename?: 'Post'
+            id: string
+            persistentId?: string | null
+          } | null
         }> | null
       }>
     }>
@@ -597,7 +605,11 @@ export type GetOptimisticPostsQuery = {
         toEvm?: { __typename?: 'EvmAccount'; id: string } | null
         pinnedResources?: Array<{
           __typename?: 'ExtensionPinnedResource'
-          post?: { __typename?: 'Post'; id: string } | null
+          post?: {
+            __typename?: 'Post'
+            id: string
+            persistentId?: string | null
+          } | null
         }> | null
       }>
     }>
@@ -739,6 +751,7 @@ export const DatahubPostFragment = gql`
       pinnedResources {
         post {
           id
+          persistentId
         }
       }
     }

--- a/src/services/subsocial/datahub/mappers.ts
+++ b/src/services/subsocial/datahub/mappers.ts
@@ -75,7 +75,7 @@ const mapPostExtensions = (
           properties: {
             ids:
               (ext.pinnedResources
-                ?.map((pinned) => pinned.post?.id)
+                ?.map((pinned) => pinned.post?.persistentId || pinned.post?.id)
                 .filter(Boolean) as [string]) ?? [],
           },
         }

--- a/src/services/subsocial/datahub/posts/fetcher.ts
+++ b/src/services/subsocial/datahub/posts/fetcher.ts
@@ -77,6 +77,7 @@ export const DATAHUB_POST_FRAGMENT = gql`
       pinnedResources {
         post {
           id
+          persistentId
         }
       }
     }

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -9,3 +9,7 @@ export function debounce(fn: Function, ms = 300) {
     timeoutId = setTimeout(() => fn.apply(this, args), ms)
   }
 }
+
+export function removeUndefinedValues<T>(data: T): T {
+  return JSON.parse(JSON.stringify(data)) as T
+}


### PR DESCRIPTION
Currently the slow fetching is identities, in which I optimize it so that only if user sets their profile to one of the polkadot identities, it will then fetch it, otherwise no fetching needed