### PR TITLE
Minor Fixes

### DIFF
--- a/src/components/auth/LoginModal/LoginModalContent.tsx
+++ b/src/components/auth/LoginModal/LoginModalContent.tsx
@@ -167,7 +167,8 @@ export const EnterSecretKeyContent = ({
     e.preventDefault()
     beforeLogin?.()
 
-    if (await login(privateKey)) {
+    const trimmedPk = privateKey.trim()
+    if (await login(trimmedPk)) {
       afterLogin?.()
       sendEvent('login', { eventSource: 'login_modal' })
       setPrivateKey('')

--- a/src/components/chats/ChatImage.tsx
+++ b/src/components/chats/ChatImage.tsx
@@ -11,6 +11,11 @@ export type ChatImageProps = ComponentProps<'div'> & {
   rounding?: 'circle' | 'xl' | '2xl'
 }
 
+function hashChatId(chatId: string | undefined) {
+  if (!chatId) return
+  return (parseInt(chatId ?? '') * 895437) % 16777215
+}
+
 export default function ChatImage({
   chatId,
   chatTitle,
@@ -26,7 +31,12 @@ export default function ChatImage({
     }
   }
 
-  const bgColor = useRandomColor(chatId || chatTitle, { theme: 'light' })
+  const bgColor = useRandomColor(
+    (hashChatId(chatId) || chatTitle || '').toString(),
+    {
+      theme: 'light',
+    }
+  )
 
   const roundingMap = {
     circle: 'rounded-full',

--- a/src/components/chats/ChatItem/ChatItemMenus.tsx
+++ b/src/components/chats/ChatItem/ChatItemMenus.tsx
@@ -8,7 +8,6 @@ import FloatingMenus, {
 import MetadataModal from '@/components/modals/MetadataModal'
 import ModerationModal from '@/components/moderation/ModerationModal'
 import Toast from '@/components/Toast'
-import { COMMUNITY_CHAT_HUB_ID } from '@/constants/hubs'
 import useAuthorizedForModeration from '@/hooks/useAuthorizedForModeration'
 import { useCanSendMessage } from '@/hooks/useCanSendMessage'
 import useIsOwnerOfPost from '@/hooks/useIsOwnerOfPost'
@@ -229,15 +228,13 @@ export default function ChatItemMenus({
         beforeLogin={() => (isLoggingInWithKey.current = true)}
         afterLogin={() => (isLoggingInWithKey.current = false)}
       />
-      {COMMUNITY_CHAT_HUB_ID && (
-        <ModerationModal
-          isOpen={modalState === 'moderate'}
-          closeModal={() => setModalState(null)}
-          messageId={messageId}
-          chatId={chatId}
-          hubId={COMMUNITY_CHAT_HUB_ID}
-        />
-      )}
+      <ModerationModal
+        isOpen={modalState === 'moderate'}
+        closeModal={() => setModalState(null)}
+        messageId={messageId}
+        chatId={chatId}
+        hubId={hubId}
+      />
     </>
   )
 }

--- a/src/components/chats/ChatItem/ChatRelativeTime.tsx
+++ b/src/components/chats/ChatItem/ChatRelativeTime.tsx
@@ -7,10 +7,12 @@ import { useChatListContext } from '../ChatList'
 
 export type ChatRelativeTimeProps = ComponentProps<'span'> & {
   createdAtTime: string | number
+  isUpdated?: boolean
 }
 
 export default function ChatRelativeTime({
   createdAtTime,
+  isUpdated,
   ...props
 }: ChatRelativeTimeProps) {
   const rerender = useRerender()
@@ -64,6 +66,7 @@ export default function ChatRelativeTime({
           }}
           className={cx('text-xs', props.className)}
         >
+          {isUpdated && 'edited '}
           {relativeTime}
         </span>
       )}

--- a/src/components/chats/ChatItem/variants/DefaultChatItem.tsx
+++ b/src/components/chats/ChatItem/variants/DefaultChatItem.tsx
@@ -20,7 +20,7 @@ export default function DefaultChatItem({
 }: DefaultChatItemProps) {
   const messageId = message.id
 
-  const { createdAtTime, ownerId } = message.struct
+  const { createdAtTime, ownerId, isUpdated } = message.struct
   const { inReplyTo, body, link, linkMetadata } = message.content || {}
 
   return (
@@ -44,6 +44,7 @@ export default function DefaultChatItem({
             <ChatRelativeTime
               createdAtTime={createdAtTime}
               className='text-xs text-text-muted'
+              isUpdated={isUpdated}
             />
           </div>
         )}
@@ -95,6 +96,7 @@ export default function DefaultChatItem({
           >
             <ChatRelativeTime
               createdAtTime={createdAtTime}
+              isUpdated={isUpdated}
               className='text-xs text-text-muted dark:text-text-muted-on-primary'
             />
             <MessageStatusIndicator message={message} />

--- a/src/components/chats/ChatItem/variants/EmojiChatItem.tsx
+++ b/src/components/chats/ChatItem/variants/EmojiChatItem.tsx
@@ -31,7 +31,7 @@ export default function EmojiChatItem({
 }: EmojiChatItemProps) {
   const messageId = message.id
 
-  const { createdAtTime, ownerId } = message.struct
+  const { createdAtTime, ownerId, isUpdated } = message.struct
   const { inReplyTo, body } = message.content || {}
 
   const emojiCount = getEmojiAmount(body ?? '')
@@ -58,6 +58,7 @@ export default function EmojiChatItem({
             className={cx('mr-2 text-sm font-medium text-text-secondary')}
           />
           <ChatRelativeTime
+            isUpdated={isUpdated}
             createdAtTime={createdAtTime}
             className='text-xs text-text-muted'
           />
@@ -99,6 +100,7 @@ export default function EmojiChatItem({
       {isMyMessage && (
         <div className='mt-auto flex items-center gap-1 rounded-2xl px-2.5 pb-1.5'>
           <ChatRelativeTime
+            isUpdated={isUpdated}
             className='text-xs text-text-muted'
             createdAtTime={createdAtTime}
           />

--- a/src/components/extensions/common/CommonChatItem.tsx
+++ b/src/components/extensions/common/CommonChatItem.tsx
@@ -54,7 +54,7 @@ export default function CommonChatItem({
   const myAddress = useMyMainAddress()
   const parentProxyAddress = useMyAccount((state) => state.parentProxyAddress)
   const { struct, content } = message
-  const { ownerId, createdAtTime, dataType } = struct
+  const { ownerId, createdAtTime, dataType, isUpdated } = struct
   const { inReplyTo, body } = content || {}
 
   const isMyMessage =
@@ -75,6 +75,7 @@ export default function CommonChatItem({
       )}
     >
       <ChatRelativeTime
+        isUpdated={isUpdated}
         createdAtTime={createdAtTime}
         className={cx(
           'text-xs text-text-muted',
@@ -106,6 +107,7 @@ export default function CommonChatItem({
               className={cx('mr-2 text-sm font-medium text-text-secondary')}
             />
             <ChatRelativeTime
+              isUpdated={isUpdated}
               createdAtTime={createdAtTime}
               className='text-xs text-text-muted'
               style={{ color: textColor }}

--- a/src/components/modals/about/AboutChatModal.tsx
+++ b/src/components/modals/about/AboutChatModal.tsx
@@ -6,7 +6,7 @@ import PluralText from '@/components/PluralText'
 import ProfilePreview from '@/components/ProfilePreview'
 import ProfilePreviewModalWrapper from '@/components/ProfilePreviewModalWrapper'
 import TruncatedText from '@/components/TruncatedText'
-import { COMMUNITY_CHAT_HUB_ID } from '@/constants/hubs'
+import { isCommunityHubId } from '@/constants/hubs'
 import useAuthorizedForModeration from '@/hooks/useAuthorizedForModeration'
 import useIsInIframe from '@/hooks/useIsInIframe'
 import useIsJoinedToChat from '@/hooks/useIsJoinedToChat'
@@ -75,9 +75,10 @@ export default function AboutChatModal({
   const content = chat?.content
   if (!content) return null
 
+  const hubId = chat.struct.spaceId
   const chatUrl = urlJoin(getCurrentUrlOrigin(), getChatPageLink(router))
   const chatOwner = chat.struct.ownerId
-  const isChatInsideCommunityHub = chat.struct.spaceId === COMMUNITY_CHAT_HUB_ID
+  const isChatInsideCommunityHub = isCommunityHubId(hubId)
 
   const contentList: AboutModalProps['contentList'] = [
     {
@@ -302,9 +303,9 @@ export default function AboutChatModal({
         onBackClick={closeModal}
         formProps={{ chat }}
       />
-      {COMMUNITY_CHAT_HUB_ID && (
+      {hubId && (
         <ModerationInfoModal
-          hubId={COMMUNITY_CHAT_HUB_ID}
+          hubId={hubId}
           isOpen={openedModalType === 'moderation'}
           closeModal={closeModal}
           onBackClick={closeModal}

--- a/src/constants/hubs.ts
+++ b/src/constants/hubs.ts
@@ -49,7 +49,11 @@ export function getPinnedChatsInHubId(hubId: string) {
   return PINNED_CHATS_IN_HUB_ID[hubId] ?? []
 }
 
-export const COMMUNITY_CHAT_HUB_ID: string | null = getCommunityHubId() || null
+export const PRIMARY_COMMUNITY_HUB_ID = getCommunityHubId()
+const COMMUNITY_CHAT_HUB_ID: string[] = [PRIMARY_COMMUNITY_HUB_ID, '1025']
+export const isCommunityHubId = (hubId: string | undefined) =>
+  COMMUNITY_CHAT_HUB_ID.includes(hubId ?? '')
+
 export const PINNED_HUB_IDS = [COMMUNITY_CHAT_HUB_ID, '1031'].filter(
   Boolean
 ) as string[]

--- a/src/hooks/useAuthorizedForModeration.ts
+++ b/src/hooks/useAuthorizedForModeration.ts
@@ -1,4 +1,3 @@
-import { COMMUNITY_CHAT_HUB_ID } from '@/constants/hubs'
 import { getPostQuery } from '@/services/api/query'
 import { getModeratorQuery } from '@/services/datahub/moderation/query'
 import { useMyMainAddress } from '@/stores/my-account'
@@ -21,8 +20,6 @@ export default function useAuthorizedForModeration(
   )
 
   const isAdmin = moderator?.appIds.includes(getAppId())
-  if (!COMMUNITY_CHAT_HUB_ID && !isAdmin)
-    return { isAuthorized: false, isOwner }
 
   return {
     isAuthorized: !!(

--- a/src/hooks/useIsAddressBlockedInChat.ts
+++ b/src/hooks/useIsAddressBlockedInChat.ts
@@ -1,5 +1,6 @@
 import { getPostQuery } from '@/services/api/query'
 import { getBlockedResourcesQuery } from '@/services/datahub/moderation/query'
+import { getAppId } from '@/utils/env/client'
 import { useMemo } from 'react'
 
 export default function useIsAddressBlockedInChat(
@@ -25,14 +26,20 @@ export default function useIsAddressBlockedInChat(
   })
   const blockedInChat = chatModerationData?.blockedResources.address
 
+  const { data: appModeration } = getBlockedResourcesQuery.useQuery({
+    appId: getAppId(),
+  })
+  const blockedInApp = appModeration?.blockedResources.address
+
   const blockedAddressesSet = useMemo(
     () =>
       new Set([
         ...(blockedInOriginalHub ?? []),
         ...(blockedInHub ?? []),
         ...(blockedInChat ?? []),
+        ...(blockedInApp ?? []),
       ]),
-    [blockedInOriginalHub, blockedInHub, blockedInChat]
+    [blockedInOriginalHub, blockedInHub, blockedInChat, blockedInApp]
   )
 
   return address && blockedAddressesSet.has(address)

--- a/src/modules/chat/ChatPage/ChatPage.tsx
+++ b/src/modules/chat/ChatPage/ChatPage.tsx
@@ -10,7 +10,6 @@ import DefaultLayout from '@/components/layouts/DefaultLayout'
 import LinkText from '@/components/LinkText'
 import { getPluralText } from '@/components/PluralText'
 import Spinner from '@/components/Spinner'
-import { COMMUNITY_CHAT_HUB_ID } from '@/constants/hubs'
 import useAuthorizedForModeration from '@/hooks/useAuthorizedForModeration'
 import usePrevious from '@/hooks/usePrevious'
 import useWrapInRef from '@/hooks/useWrapInRef'
@@ -134,7 +133,7 @@ export default function ChatPage({
 
   const chatEntityId = chat?.entityId
   useEffect(() => {
-    if (!COMMUNITY_CHAT_HUB_ID || !isOwner) return
+    if (!isOwner) return
     if (!isAuthorized && !isLoading && chatEntityId && isSignerReady) {
       if (!moderatorData?.exist) {
         commitModerationAction({

--- a/src/modules/chat/HomePage/HomePage.tsx
+++ b/src/modules/chat/HomePage/HomePage.tsx
@@ -4,7 +4,7 @@ import NewCommunityModal from '@/components/community/NewCommunityModal'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
 import NavbarWithSearch from '@/components/navbar/Navbar/custom/NavbarWithSearch'
 import Tabs, { TabsProps } from '@/components/Tabs'
-import { COMMUNITY_CHAT_HUB_ID } from '@/constants/hubs'
+import { PRIMARY_COMMUNITY_HUB_ID } from '@/constants/hubs'
 import useSearch from '@/hooks/useSearch'
 import { getFollowedPostIdsByAddressQuery } from '@/services/subsocial/posts'
 import { useSendEvent } from '@/stores/analytics'
@@ -179,7 +179,7 @@ export default function HubsPage(props: HubsPageProps) {
           withHashIntegration={false}
           tabsRightElement={
             isLoggedIn &&
-            COMMUNITY_CHAT_HUB_ID && (
+            PRIMARY_COMMUNITY_HUB_ID && (
               <div className='ml-auto mr-2 flex items-center justify-end self-stretch pl-2'>
                 <Button
                   size='xs'
@@ -206,11 +206,11 @@ export default function HubsPage(props: HubsPageProps) {
         />
       </SearchChannelsWrapper>
 
-      {COMMUNITY_CHAT_HUB_ID && (
+      {PRIMARY_COMMUNITY_HUB_ID && (
         <NewCommunityModal
           isOpen={isOpenNewCommunity}
           closeModal={() => setIsOpenNewCommunity(false)}
-          hubId={COMMUNITY_CHAT_HUB_ID}
+          hubId={PRIMARY_COMMUNITY_HUB_ID}
         />
       )}
     </DefaultLayout>

--- a/src/modules/chat/HomePage/MyChatsContent.tsx
+++ b/src/modules/chat/HomePage/MyChatsContent.tsx
@@ -4,7 +4,7 @@ import ChatPreviewList from '@/components/chats/ChatPreviewList'
 import ChatPreviewSkeleton from '@/components/chats/ChatPreviewSkeleton'
 import NewCommunityModal from '@/components/community/NewCommunityModal'
 import Container from '@/components/Container'
-import { COMMUNITY_CHAT_HUB_ID } from '@/constants/hubs'
+import { PRIMARY_COMMUNITY_HUB_ID } from '@/constants/hubs'
 import { getPostQuery } from '@/services/api/query'
 import {
   getFollowedPostIdsByAddressQuery,
@@ -180,7 +180,7 @@ function NoChats({ changeTab }: NoChatsProps) {
         <p className='text-text-muted'>
           Here will be all the chats you joined or created
         </p>
-        {COMMUNITY_CHAT_HUB_ID ? (
+        {PRIMARY_COMMUNITY_HUB_ID ? (
           <>
             <Button
               className='mt-4 w-full'
@@ -219,11 +219,11 @@ function NoChats({ changeTab }: NoChatsProps) {
         )}
       </Container>
 
-      {COMMUNITY_CHAT_HUB_ID && (
+      {PRIMARY_COMMUNITY_HUB_ID && (
         <NewCommunityModal
           isOpen={isOpenNewCommunity}
           closeModal={() => setIsOpenNewCommunity(false)}
-          hubId={COMMUNITY_CHAT_HUB_ID}
+          hubId={PRIMARY_COMMUNITY_HUB_ID}
         />
       )}
     </>

--- a/src/modules/chat/HubPage/HubPage.tsx
+++ b/src/modules/chat/HubPage/HubPage.tsx
@@ -5,7 +5,7 @@ import NewCommunityModal from '@/components/community/NewCommunityModal'
 import Container from '@/components/Container'
 import FloatingMenus from '@/components/floating/FloatingMenus'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
-import { COMMUNITY_CHAT_HUB_ID } from '@/constants/hubs'
+import { isCommunityHubId } from '@/constants/hubs'
 import useSearch from '@/hooks/useSearch'
 import { useSendEvent } from '@/stores/analytics'
 import { useMyAccount } from '@/stores/my-account'
@@ -30,7 +30,7 @@ export type HubPageProps = {
   hubId: string
 }
 export default function HubPage({ hubId }: HubPageProps) {
-  const isCommunityHub = hubId === COMMUNITY_CHAT_HUB_ID
+  const isCommunityHub = isCommunityHubId(hubId)
 
   const [sortBy, setSortBy] = useState<SortChatOption | null>(null)
   useEffect(() => {

--- a/src/pages/api/version.ts
+++ b/src/pages/api/version.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-const VERSION = '17'
+const VERSION = '18'
 
 export default function handler(_: NextApiRequest, res: NextApiResponse) {
   res.status(200).json(VERSION)

--- a/src/services/datahub/moderation/subscription.tsx
+++ b/src/services/datahub/moderation/subscription.tsx
@@ -233,12 +233,15 @@ async function processBlockedResources(
   const ctxAppIds = entity.organization.ctxAppIds
   const entityAppId = entity.ctxAppIds
   const appId = getAppId()
-  const isBlockedUsingAppContext =
+
+  const isBlockedInAppContext =
+    isNowBlocked && entityAppId.some((id) => id === appId || id === '*')
+  const isAppContextRelated =
     appId &&
     ctxAppIds?.includes(appId) &&
-    entityAppId.some((id) => id === appId || id === '*')
+    (isBlockedInAppContext || !isNowBlocked)
 
-  if (isBlockedUsingAppContext) {
+  if (isAppContextRelated) {
     getBlockedResourcesQuery.setQueryData(queryClient, { appId }, (oldData) => {
       if (oldData === undefined) return undefined
       const newResources = updateBlockedResourceData(oldData, {

--- a/src/services/datahub/moderation/subscription.tsx
+++ b/src/services/datahub/moderation/subscription.tsx
@@ -167,7 +167,6 @@ async function processBlockedResourcesEvent(
   queryClient: QueryClient,
   eventData: SubscribeBlockedResourcesSubscription['moderationBlockedResource']
 ) {
-  console.log(eventData.event, processedJustNowIds.has(eventData.entity.id))
   if (
     eventData.event ===
       DataHubSubscriptionEventEnum.ModerationBlockedResourceCreated ||

--- a/src/services/subsocial/commentIds/mutation.ts
+++ b/src/services/subsocial/commentIds/mutation.ts
@@ -142,6 +142,10 @@ export function useSendMessage(config?: MutationConfig<SendMessageParams>) {
                       extensions: data.extensions,
                     }
                   : null,
+                struct: {
+                  ...old.struct,
+                  isUpdated: true,
+                },
               }
             })
           } else {


### PR DESCRIPTION
# Fixes
- Improve chat image background (because for example, chatId 1001 and 1002 will have very bg color)
- Trim pk before using it to login to prevent trailing space or enter makes it invalid
- Check is user blocked also using the app moderated data
- Show `edited` label for edited message
- Fix moderation undo not working properly (updating immediately) for super admin
- Enable to create new chats in 1025 space for testing purposes