### PR TITLE
Fix Client Side Error

### DIFF
--- a/src/components/extensions/donate/DonateModal/donateForm/mutation.tsx
+++ b/src/components/extensions/donate/DonateModal/donateForm/mutation.tsx
@@ -36,11 +36,25 @@ export function useSubstrateDonatoin(
 
   useEffect(() => {
     if (parentProxyAddress && accounts) {
-      const signer = accounts.find(
-        (account) =>
-          new GenericAccountId(registry, account.address).toString() ===
-          new GenericAccountId(registry, parentProxyAddress).toString()
-      )?.signer
+      const signer = accounts.find((account) => {
+        let genericAccountAddress = ''
+        try {
+          genericAccountAddress = new GenericAccountId(
+            registry,
+            account.address
+          ).toString()
+        } catch {}
+
+        let genericProxyAddress = ''
+        try {
+          genericProxyAddress = new GenericAccountId(
+            registry,
+            parentProxyAddress
+          ).toString()
+        } catch {}
+
+        return genericAccountAddress === parentProxyAddress
+      })?.signer
 
       if (signer) {
         connectWallet(parentProxyAddress, signer as Signer)


### PR DESCRIPTION
Issue

If you have connected your wallet and then in your wallet, it has connected evm addresses, it will parse the addresses to substrate generic account id in donate modal, and it doesn't have try catch, so it results in client side error