### PR TITLE
Fix wrong logic for relative time

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -7,7 +7,11 @@ export function getTimeRelativeToNow(date: Date | string | number) {
   const dateObj = new Date(date)
   const now = new Date()
 
-  if (now.getDay() === dateObj.getDay()) {
+  if (
+    now.getDate() === dateObj.getDate() &&
+    now.getMonth() === dateObj.getMonth() &&
+    now.getFullYear() === dateObj.getFullYear()
+  ) {
     return dayjs(date).format('HH:mm')
   }
 


### PR DESCRIPTION
Right now, it renders with format HH:mm for every message that has same day, along with the ones that has different dates, months, or years