### PR TITLE
Integrate multiple address pool query fetching for address like count

### DIFF
--- a/src/components/extensions/donate/DonateRepliedMessagePreviewPart.tsx
+++ b/src/components/extensions/donate/DonateRepliedMessagePreviewPart.tsx
@@ -23,7 +23,7 @@ const DonateRepliedMessagePreviewPart = ({
   }
 
   return (
-    <span>
+    <span className='flex-shrink-0'>
       <div
         className={cx(
           getCommonClassNames('donateMessagePreviewBg'),


### PR DESCRIPTION
# Issue
when user first access the chat page, if the user has connected polkadot address
the first render the address in the state is still grill account, and some miliseconds later it loads the parent proxy address
this causes address like queries to be pooled together for both addresses

with the old implementation, it will result in only the grill account address that is fetched, because that's the first query pooled
