### PR TITLE
Fix wallet connection

### DIFF
--- a/src/components/auth/common/polkadot-connect/hooks/useAccountsFromPreferredWallet.tsx
+++ b/src/components/auth/common/polkadot-connect/hooks/useAccountsFromPreferredWallet.tsx
@@ -10,8 +10,11 @@ export default function useAccountsFromPreferredWallet(onError?: () => void) {
   const setPreferredWallet = useMyAccount((state) => state.setPreferredWallet)
   const [accounts, setAccounts] = useState<WalletAccount[] | null>(null)
   const onErrorRef = useWrapInRef(onError)
+  const isInitialized = useMyAccount.use.isInitialized()
 
   useEffect(() => {
+    if (!isInitialized) return
+
     const unsub = enableWallet({
       listener: (accounts) => setAccounts(accounts ?? []),
       onError: (err) => {
@@ -29,7 +32,7 @@ export default function useAccountsFromPreferredWallet(onError?: () => void) {
     return () => {
       unsub.then((unsub) => unsub?.())
     }
-  }, [preferredWallet, onErrorRef, setPreferredWallet])
+  }, [preferredWallet, onErrorRef, setPreferredWallet, isInitialized])
 
   return { accounts, isLoading: accounts === null }
 }

--- a/src/stores/my-account.tsx
+++ b/src/stores/my-account.tsx
@@ -69,6 +69,7 @@ type Actions = {
   disconnectProxy: () => void
   _subscribeEnergy: () => void
   _subscribeConnectedWalletEnergy: () => void
+  _readPreferredWalletFromStorage: () => Wallet | undefined
 }
 
 const initialState: State = {
@@ -281,21 +282,24 @@ const useMyAccountBase = create<State & Actions>()((set, get) => ({
 
     set({ ...initialState, isInitialized: true, isInitializedProxy: true })
   },
+  _readPreferredWalletFromStorage: () => {
+    const preferredWallet = preferredWalletStorage.get()
+    let wallet: Wallet | undefined
+    if (preferredWallet) {
+      wallet = getWallets().find((wallet) => wallet.title === preferredWallet)
+      if (wallet) set({ preferredWallet: wallet })
+      else preferredWalletStorage.remove()
+    }
+    return wallet
+  },
   init: async () => {
-    const { isInitialized, login } = get()
+    const { isInitialized, login, _readPreferredWalletFromStorage } = get()
 
     // Prevent multiple initialization
     if (isInitialized !== undefined) return
     set({ isInitialized: false })
 
-    const preferredWallet = preferredWalletStorage.get()
-    if (preferredWallet) {
-      const wallet = getWallets().find(
-        (wallet) => wallet.title === preferredWallet
-      )
-      if (wallet) set({ preferredWallet: wallet })
-      else preferredWalletStorage.remove()
-    }
+    _readPreferredWalletFromStorage()
 
     const encodedSecretKey = accountStorage.get()
     const parentProxyAddress = parentProxyAddressStorage.get()
@@ -457,10 +461,19 @@ export async function enableWallet({
 }) {
   let preferredWallet = useMyAccount.getState().preferredWallet
   if (!preferredWallet) {
-    const firstInstalledWallet = getWallets().find((wallet) => wallet.installed)
-    if (!firstInstalledWallet)
-      return onError(new Error('No supported wallet found'))
-    preferredWallet = firstInstalledWallet
+    const fromStorage = useMyAccount
+      .getState()
+      ._readPreferredWalletFromStorage()
+    if (fromStorage) {
+      preferredWallet = fromStorage
+    } else {
+      const firstInstalledWallet = getWallets().find(
+        (wallet) => wallet.installed
+      )
+      if (!firstInstalledWallet)
+        return onError(new Error('No supported wallet found'))
+      preferredWallet = firstInstalledWallet
+    }
   }
 
   try {

--- a/src/stores/my-account.tsx
+++ b/src/stores/my-account.tsx
@@ -288,6 +288,15 @@ const useMyAccountBase = create<State & Actions>()((set, get) => ({
     if (isInitialized !== undefined) return
     set({ isInitialized: false })
 
+    const preferredWallet = preferredWalletStorage.get()
+    if (preferredWallet) {
+      const wallet = getWallets().find(
+        (wallet) => wallet.title === preferredWallet
+      )
+      if (wallet) set({ preferredWallet: wallet })
+      else preferredWalletStorage.remove()
+    }
+
     const encodedSecretKey = accountStorage.get()
     const parentProxyAddress = parentProxyAddressStorage.get()
 
@@ -310,15 +319,6 @@ const useMyAccountBase = create<State & Actions>()((set, get) => ({
     }
 
     set({ isInitialized: true })
-
-    const preferredWallet = preferredWalletStorage.get()
-    if (preferredWallet) {
-      const wallet = getWallets().find(
-        (wallet) => wallet.title === preferredWallet
-      )
-      if (wallet) set({ preferredWallet: wallet })
-      else preferredWalletStorage.remove()
-    }
 
     if (parentProxyAddress) {
       set({ parentProxyAddress })


### PR DESCRIPTION
Issue:
Enable wallet is called before preferredWallet is read from storage, causing first installed extension is the one that gets enabled